### PR TITLE
Add the Z-function

### DIFF
--- a/content/strings/KMP.h
+++ b/content/strings/KMP.h
@@ -3,10 +3,13 @@
  * License: CC0
  * Description: pi[x] computes the length of the longest prefix of s that ends at x, other than s[0..x] itself
  * This is used by find to find all occurances of a string.
+ * z[x] computes the longest prefix of s that starts at x. Note that z[0] = 0 though, which you often want.
+ * It takes pi as input
  * Time: O(pattern) for pi, O(word + pattern) for find
  * Status: Tested on Kattis, stringmatching
  * Usage:
  *  vi p = pi(pattern); vi occ = find(word, p);
+ *  vi zf = z(p);
  */
 #pragma once
 
@@ -18,6 +21,15 @@ vi pi(const string& s) {
 		p[i] = g + (s[i] == s[g]);
 	}
 	return p;
+}
+
+vi z(const vector<int>& p) {
+	vi Z(sz(p));
+    	rep(i,0,sz(p))
+        	Z[i-p[i]+1] = max(Z[i-p[i]+1], p[i]);
+    	rep(i,0,sz(p)) if (p[i] && Z[p[i] - 1])
+        	Z[i] = max(Z[i], P[Z[P[i] - 1] - 1]);
+	return Z;
 }
 
 vi match(const string& s, const string& pat) {


### PR DESCRIPTION
The Z-function computes the longest common prefix of the string itself.
Uses the pi array instead to be a bit shorter. Also, the conversion itself is good to document.