### PR TITLE
Fix compiler warning in 2sat.h

### DIFF
--- a/content/graph/2sat.h
+++ b/content/graph/2sat.h
@@ -59,7 +59,7 @@ struct TwoSat {
 			x = z.back(); z.pop_back();
 			comp[x] = time;
 			if (values[x>>1] == -1)
-				values[x>>1] = 1 - x&1;
+				values[x>>1] = !(x&1);
 		} while (x != i);
 		return val[i] = low;
 	}


### PR DESCRIPTION
The expression `1 - x&1` produces a warning since the compiler suggests that we should add parentheses so it becomes `(1 - x)&1`.

In this specific case however, we have that `(1 - x)&1 == 1 - (x&1) == !(x&1)`.

I suggest we use `!(x&1)`, but we could also pick any of the two others with parentheses.