### PR TITLE
Changed Miller Rabin to deterministic variant

### DIFF
--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -20,7 +20,7 @@ bool isPrime(ull n) {
         ull p = mod_pow(a, d, n), i = d;
         while (p != n - 1 && i != n - 1 && p != 1)
             i <<= 1, p = mod_mul(p, p, n);
-        if (i == n - 1 && i > d) return false;
+        if (p != n-1 && i != d) return false;
     }
     return true;
 }

--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -1,10 +1,10 @@
 /**
- * Author: chilli, c1729
+ * Author: chilli, c1729, Simon Lindholm
  * Date: 2019-03-28
  * License: CC0
- * Source: Bases taken from https://miller-rabin.appspot.com/
- * Description: Deterministic Miller-Rabin primality test. Guaranteed to work for numbers up to 2^64.
- * Can test 15 random numbers for $a$ for probabilistic test on values higher than 2^64.
+ * Source: Wikipedia, https://miller-rabin.appspot.com/
+ * Description: Deterministic Miller-Rabin primality test.
+ * Guaranteed to work for numbers up to 2^64; for larger numbers, extend A randomly.
  * Time: 7 times the complexity of $a^b \mod c$.
  */
 #pragma once
@@ -12,16 +12,14 @@
 #include "ModMulLL.h"
 
 bool isPrime(ull n) {
-    if (n <= 1) return false;
-    for (ull p : {2, 3, 5, 13, 19, 73, 193, 407521, 299210837})
-        if (n % p == 0) return (n == p);
-    ull d = n - 1;
-    while (!(d & 1)) d >>= 1;
-    for (ull a : {2, 325, 9375, 28178, 450775, 9780504, 1795265022}) { 
-        ull p = mod_pow(a, d, n), i = d;
-        while (p != n - 1 && i != n - 1 && p != 1)
-            i <<= 1, p = mod_mul(p, p, n);
-        if (p != n-1 && i != d) return false;
-    }
-    return true;
+	if (n < 2 || n % 2 == 0 || n % 3 == 0) return n - 2 < 2;
+	ull A[] = {2, 325, 9375, 28178, 450775, 9780504, 1795265022},
+	    s = __builtin_ctzll(n-1), d = n >> s;
+	trav(a, A) {   // ^ count trailing zeroes
+		ull p = mod_pow(a, d, n), i = s;
+		while (p != 1 && p != n - 1 && a % n && i--)
+			p = mod_mul(p, p, n);
+		if (p != n-1 && i != s) return 0;
+	}
+	return 1;
 }

--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -2,6 +2,7 @@
  * Author: chilli, c1729
  * Date: 2019-03-28
  * License: CC0
+ * Source: Bases taken from https://miller-rabin.appspot.com/
  * Description: Deterministic Miller-Rabin primality test. Guaranteed to work for numbers up to 2^64.
  * Can test 15 random numbers for $a$ for probabilistic test on values higher than 2^64.
  * Time: 7 times the complexity of $a^b \mod c$.

--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -2,9 +2,7 @@
  * Author: chilli, c1729
  * Date: 2019-03-28
  * License: CC0
- * Description: Deterministic Miller-Rabin primality test.
- * Guaranteed to be correct, 2x as probabilistic version for <1e9, 3x as fast
- * for 1e15
+ * Description: Deterministic Miller-Rabin primality test. Numbers taken from 
  * Time: 7 times the complexity of $a^b \mod c$.
  */
 #pragma once
@@ -12,10 +10,10 @@
 #include "ModMulLL.h"
 
 bool prime(ull n) {
-    vector<ull> ps({2, 3, 5, 13, 19, 73, 193, 407521, 299210837});
     vector<ull> cs({2, 325, 9375, 28178, 450775, 9780504, 1795265022});
-    if (n <= 1 || any_of(all(ps), [&](ull p) { return n % p == 0; }))
-        return count(all(ps), n) > 0;
+    if (n <= 1) return false;
+    for (ull p : {2, 3, 5, 13, 19, 73, 193, 407521, 299210837})
+        if (n % p == 0) return (n == p);
     ull d = n - 1, s = 0;
     while (!(d & 1)) d >>= 1, s++;
     return !any_of(all(cs), [&](ull a) {

--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -2,7 +2,8 @@
  * Author: chilli, c1729
  * Date: 2019-03-28
  * License: CC0
- * Description: Deterministic Miller-Rabin primality test. Works for numbers up to 2^64
+ * Description: Deterministic Miller-Rabin primality test. Guaranteed to work for numbers up to 2^64.
+ * Can test 15 random numbers for $a$ for probabilistic test on values higher than 2^64.
  * Time: 7 times the complexity of $a^b \mod c$.
  */
 #pragma once
@@ -15,7 +16,7 @@ bool isPrime(ull n) {
         if (n % p == 0) return (n == p);
     ull d = n - 1;
     while (!(d & 1)) d >>= 1;
-    for (ull a : {2, 325, 9375, 28178, 450775, 9780504, 1795265022}) {
+    for (ull a : {2, 325, 9375, 28178, 450775, 9780504, 1795265022}) { 
         ull p = mod_pow(a, d, n), i = d;
         while (p != n - 1 && i != n - 1 && p != 1)
             i <<= 1, p = mod_mul(p, p, n);

--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -2,24 +2,24 @@
  * Author: chilli, c1729
  * Date: 2019-03-28
  * License: CC0
- * Description: Deterministic Miller-Rabin primality test. Numbers taken from 
+ * Description: Deterministic Miller-Rabin primality test. Works for numbers up to 2^64
  * Time: 7 times the complexity of $a^b \mod c$.
  */
 #pragma once
 
 #include "ModMulLL.h"
 
-bool prime(ull n) {
-    vector<ull> cs({2, 325, 9375, 28178, 450775, 9780504, 1795265022});
+bool isPrime(ull n) {
     if (n <= 1) return false;
     for (ull p : {2, 3, 5, 13, 19, 73, 193, 407521, 299210837})
         if (n % p == 0) return (n == p);
-    ull d = n - 1, s = 0;
-    while (!(d & 1)) d >>= 1, s++;
-    return !any_of(all(cs), [&](ull a) {
-        for (ull i = 0, p = mod_pow(a, d, n); i < s; i++, p = mod_mul(p, p, n))
-            if (p == n - 1 || (i == 0 && p == 1))
-                return false;
-        return true;
-    });
+    ull d = n - 1;
+    while (!(d & 1)) d >>= 1;
+    for (ull a : {2, 325, 9375, 28178, 450775, 9780504, 1795265022}) {
+        ull p = mod_pow(a, d, n), i = d;
+        while (p != n - 1 && i != n - 1 && p != 1)
+            i <<= 1, p = mod_mul(p, p, n);
+        if (i == n - 1 && i > d) return false;
+    }
+    return true;
 }

--- a/content/number-theory/MillerRabin.h
+++ b/content/number-theory/MillerRabin.h
@@ -1,30 +1,27 @@
 /**
- * Author: Lukas Polacek
- * Date: 2010-01-26
+ * Author: chilli, c1729
+ * Date: 2019-03-28
  * License: CC0
- * Source: TopCoder tutorial
- * Description: Miller-Rabin primality probabilistic test.
- * Probability of failing one iteration is at most 1/4. 15 iterations should be
- * enough for 50-bit numbers.
- * Time: 15 times the complexity of $a^b \mod c$.
+ * Description: Deterministic Miller-Rabin primality test.
+ * Guaranteed to be correct, 2x as probabilistic version for <1e9, 3x as fast
+ * for 1e15
+ * Time: 7 times the complexity of $a^b \mod c$.
  */
 #pragma once
 
 #include "ModMulLL.h"
 
-bool prime(ull p) {
-	if (p == 2) return true;
-	if (p == 1 || p % 2 == 0) return false;
-	ull s = p - 1;
-	while (s % 2 == 0) s /= 2;
-	rep(i,0,15) {
-		ull a = rand() % (p - 1) + 1, tmp = s;
-		ull mod = mod_pow(a, tmp, p);
-		while (tmp != p - 1 && mod != 1 && mod != p - 1) {
-			mod = mod_mul(mod, mod, p);
-			tmp *= 2;
-		}
-		if (mod != p - 1 && tmp % 2 == 0) return false;
-	}
-	return true;
+bool prime(ull n) {
+    vector<ull> ps({2, 3, 5, 13, 19, 73, 193, 407521, 299210837});
+    vector<ull> cs({2, 325, 9375, 28178, 450775, 9780504, 1795265022});
+    if (n <= 1 || any_of(all(ps), [&](ull p) { return n % p == 0; }))
+        return count(all(ps), n) > 0;
+    ull d = n - 1, s = 0;
+    while (!(d & 1)) d >>= 1, s++;
+    return !any_of(all(cs), [&](ull a) {
+        for (ull i = 0, p = mod_pow(a, d, n); i < s; i++, p = mod_mul(p, p, n))
+            if (p == n - 1 || (i == 0 && p == 1))
+                return false;
+        return true;
+    });
 }


### PR DESCRIPTION
It's about 2x faster for <1e9 and 3x faster for ~1e15. 

Also, the determinism is nice. Currently, the probabilistic Miller Rabin with 15 iterations is expected to fail in about a thousand seconds worth of computation on worst case input.

