### PR TITLE
Updated NTT to be similar to the rewritten FFT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 a.out
 header.tmp
+.vscode

--- a/content/numerical/FastFourierTransform.h
+++ b/content/numerical/FastFourierTransform.h
@@ -44,7 +44,7 @@ vd conv(const vd& a, const vd& b) {
 	rep(i,0,sz(b)) in[i].imag(b[i]);
 	fft(in, rt, rev, n);
 	trav(x, in) x *= x;
-	rep(i,0,n) out[i] = in[(n - i) & (n - 1)] - conj(in[i]);
+	rep(i,0,n) out[i] = in[-i & (n - 1)] - conj(in[i]);
 	fft(out, rt, rev, n);
 	rep(i,0,sz(res)) res[i] = imag(out[i]) / (4*n);
 	return res;

--- a/content/numerical/NumberTheoreticTransform.h
+++ b/content/numerical/NumberTheoreticTransform.h
@@ -36,13 +36,12 @@ vl conv(const vl& a, const vl& b) {
 	vl L(a), R(b), out(n), rt(n, 1), rev(n);
 	L.resize(n), R.resize(n);
 	rep(i,0,n) rev[i] = (rev[i / 2] | (i & 1) << B) / 2;
-	int curL = mod / 2;
+	ll curL = mod / 2, inv = modpow(n, mod - 2);
 	for (int k = 2; k < n; k *= 2) {
 		ll z[] = {1, modpow(root, curL /= 2)};
 		rep(i,k,2*k) rt[i] = rt[i / 2] * z[i & 1] % mod;
 	}
-	ntt(L, rt, rev, n), ntt(R, rt, rev, n);
-	ll inv = modpow(n, mod - 2);
+	ntt(L, rt, rev, n); ntt(R, rt, rev, n);
 	rep(i,0,n) out[-i & (n-1)] = L[i] * R[i] % mod * inv % mod;
 	ntt(out, rt, rev, n);
 	return {out.begin(), out.begin() + s};

--- a/content/numerical/NumberTheoreticTransform.h
+++ b/content/numerical/NumberTheoreticTransform.h
@@ -19,32 +19,31 @@ const ll mod = (119 << 23) + 1, root = 62; // = 998244353
 // and 483 << 21 (same root). The last two are > 10^9.
 
 typedef vector<ll> vl;
-void ntt(vl &a, vl &rt, vl &rev, int n) {
+void ntt(vl& a, vl& rt, vl& rev, int n) {
 	rep(i,0,n) if (i < rev[i]) swap(a[i], a[rev[i]]);
 	for (int k = 1; k < n; k *= 2)
-		for (int i = 0; i < n; i += 2 * k)
-			rep(j,0,k) {
+		for (int i = 0; i < n; i += 2 * k) rep(j,0,k) {
 				ll z = rt[j + k] * a[i + j + k] % mod, &ai = a[i + j];
-				a[i + j + k] = z > ai ? ai - z + mod : ai - z;
-				ai += ai + z >= mod ? z - mod : z;
-			}
+				a[i + j + k] = (z > ai ? ai - z + mod : ai - z);
+				ai += (ai + z >= mod ? z - mod : z);
+	}
 }
 
-vl conv(const vl &a, const vl &b) {
+vl conv(const vl& a, const vl& b) {
 	if (a.empty() || b.empty())
 		return {};
-	int s = sz(a) + sz(b) - 1, B = 32 - __builtin_clz(s), n = 1 << B;
+	int s = sz(a)+sz(b)-1, B = 32 - __builtin_clz(s), n = 1 << B;
 	vl L(a), R(b), out(n), rt(n, 1), rev(n);
 	L.resize(n), R.resize(n);
 	rep(i,0,n) rev[i] = (rev[i / 2] | (i & 1) << B) / 2;
 	int curL = mod / 2;
 	for (int k = 2; k < n; k *= 2) {
 		ll z[] = {1, modpow(root, curL /= 2)};
-		rep(i,k,2*k) rt[i] = rt[i / 2] * z[i & 1 ] %mod;
+		rep(i,k,2*k) rt[i] = rt[i / 2] * z[i & 1] % mod;
 	}
 	ntt(L, rt, rev, n), ntt(R, rt, rev, n);
 	ll inv = modpow(n, mod - 2);
-	rep(i,0,n) out[-i&(n-1)] = L[i] * R[i] % mod * inv % mod;
+	rep(i,0,n) out[-i & (n-1)] = L[i] * R[i] % mod * inv % mod;
 	ntt(out, rt, rev, n);
 	return {out.begin(), out.begin() + s};
 }

--- a/content/numerical/NumberTheoreticTransform.h
+++ b/content/numerical/NumberTheoreticTransform.h
@@ -33,10 +33,10 @@ void ntt(vl &a, vl &rt, vl &rev, int n) {
 vl conv(const vl &a, const vl &b) {
 	if (a.empty() || b.empty())
 		return {};
-	int s = sz(a) + sz(b) - 1, L = 32 - __builtin_clz(s), n = 1 << L;
+	int s = sz(a) + sz(b) - 1, B = 32 - __builtin_clz(s), n = 1 << B;
 	vl L(a), R(b), out(n), rt(n, 1), rev(n);
 	L.resize(n), R.resize(n);
-	rep(i,0,n) rev[i] = (rev[i / 2] | (i & 1) << L) / 2;
+	rep(i,0,n) rev[i] = (rev[i / 2] | (i & 1) << B) / 2;
 	int curL = mod / 2;
 	for (int k = 2; k < n; k *= 2) {
 		ll z[] = {1, modpow(root, curL /= 2)};

--- a/content/numerical/NumberTheoreticTransform.h
+++ b/content/numerical/NumberTheoreticTransform.h
@@ -14,9 +14,9 @@
 
 #include "../number-theory/ModPow.h"
 
-const ll mod = (119 << 23) + 1, root = 3; // = 998244353
-// For p < 2^30 there is also e.g. (5 << 25, 3), (7 << 26, 3),
-// (479 << 21, 3) and (483 << 21, 5). The last two are > 10^9.
+const ll mod = (119 << 23) + 1, root = 62; // = 998244353
+// For p < 2^30 there is also e.g. 5 << 25, 7 << 26, 479 << 21
+// and 483 << 21 (same root). The last two are > 10^9.
 
 typedef vector<ll> vl;
 void ntt(vl &a, vl &rt, vl &rev, int n) {

--- a/content/numerical/NumberTheoreticTransform.h
+++ b/content/numerical/NumberTheoreticTransform.h
@@ -1,12 +1,12 @@
 /**
- * Author: Simon Lindholm
- * Date: 2016-09-10
+ * Author: chilli
+ * Date: 2019-04-16
  * License: CC0
  * Source: based on KACTL's FFT
  * Description: Can be used for convolutions modulo specific nice primes
  * of the form $2^a b+1$, where the convolution result has size at most $2^a$.
- * For other primes/integers, use two different primes and combine with CRT.
- * Inputs must be in [0, mod)
+ * For other primes/integers, use three different primes and combine with CRT.
+ * Inputs must be in [0, mod).
  * Time: O(N \log N)
  * Status: Somewhat tested
  */

--- a/content/numerical/NumberTheoreticTransform.h
+++ b/content/numerical/NumberTheoreticTransform.h
@@ -6,49 +6,45 @@
  * Description: Can be used for convolutions modulo specific nice primes
  * of the form $2^a b+1$, where the convolution result has size at most $2^a$.
  * For other primes/integers, use two different primes and combine with CRT.
- * May return negative values.
+ * Inputs must be in [0, mod)
  * Time: O(N \log N)
  * Status: Somewhat tested
  */
 #pragma once
 
-#include "ModPow.h"
+#include "../number-theory/ModPow.h"
 
 const ll mod = (119 << 23) + 1, root = 3; // = 998244353
 // For p < 2^30 there is also e.g. (5 << 25, 3), (7 << 26, 3),
 // (479 << 21, 3) and (483 << 21, 5). The last two are > 10^9.
 
 typedef vector<ll> vl;
-void ntt(ll* x, ll* temp, ll* roots, int N, int skip) {
-	if (N == 1) return;
-	int n2 = N/2;
-	ntt(x     , temp, roots, n2, skip*2);
-	ntt(x+skip, temp, roots, n2, skip*2);
-	rep(i,0,N) temp[i] = x[i*skip];
-	rep(i,0,n2) {
-		ll s = temp[2*i], t = temp[2*i+1] * roots[skip*i];
-		x[skip*i] = (s + t) % mod; x[skip*(i+n2)] = (s - t) % mod;
-	}
+void ntt(vl &a, vl &rt, vl &rev, int n) {
+	rep(i,0,n) if (i < rev[i]) swap(a[i], a[rev[i]]);
+	for (int k = 1; k < n; k *= 2)
+		for (int i = 0; i < n; i += 2 * k)
+			rep(j,0,k) {
+				ll z = rt[j + k] * a[i + j + k] % mod, &ai = a[i + j];
+				a[i + j + k] = z > ai ? ai - z + mod : ai - z;
+				ai += ai + z >= mod ? z - mod : z;
+			}
 }
-void ntt(vl& x, bool inv = false) {
-	ll e = modpow(root, (mod-1) / sz(x));
-	if (inv) e = modpow(e, mod-2);
-	vl roots(sz(x), 1), temp = roots;
-	rep(i,1,sz(x)) roots[i] = roots[i-1] * e % mod;
-	ntt(&x[0], &temp[0], &roots[0], sz(x), 1);
-}
-vl conv(vl a, vl b) {
-	int s = sz(a) + sz(b) - 1; if (s <= 0) return {};
-	int L = s > 1 ? 32 - __builtin_clz(s - 1) : 0, n = 1 << L;
-	if (s <= 200) { // (factor 10 optimization for |a|,|b| = 10)
-		vl c(s);
-		rep(i,0,sz(a)) rep(j,0,sz(b))
-			c[i + j] = (c[i + j] + a[i] * b[j]) % mod;
-		return c;
+
+vl conv(const vl &a, const vl &b) {
+	if (a.empty() || b.empty())
+		return {};
+	int s = sz(a) + sz(b) - 1, L = 32 - __builtin_clz(s), n = 1 << L;
+	vl L(a), R(b), out(n), rt(n, 1), rev(n);
+	L.resize(n), R.resize(n);
+	rep(i,0,n) rev[i] = (rev[i / 2] | (i & 1) << L) / 2;
+	int curL = mod / 2;
+	for (int k = 2; k < n; k *= 2) {
+		ll z[] = {1, modpow(root, curL /= 2)};
+		rep(i,k,2*k) rt[i] = rt[i / 2] * z[i & 1 ] %mod;
 	}
-	a.resize(n); ntt(a);
-	b.resize(n); ntt(b);
-	vl c(n); ll d = modpow(n, mod-2);
-	rep(i,0,n) c[i] = a[i] * b[i] % mod * d % mod;
-	ntt(c, true); c.resize(s); return c;
+	ntt(L, rt, rev, n), ntt(R, rt, rev, n);
+	ll inv = modpow(n, mod - 2);
+	rep(i,0,n) out[-i&(n-1)] = L[i] * R[i] % mod * inv % mod;
+	ntt(out, rt, rev, n);
+	return {out.begin(), out.begin() + s};
 }

--- a/fuzz-tests/ntt.cpp
+++ b/fuzz-tests/ntt.cpp
@@ -10,60 +10,27 @@ typedef long long ll;
 typedef pair<int, int> pii;
 typedef vector<int> vi;
 
-const ll mod = (119 << 23) + 1, root = 3; // = 998244353
-// For p < 2^30 there is also e.g. (5 << 25, 3), (7 << 26, 3),
-// (479 << 21, 3) and (483 << 21, 5). The last two are > 10^9.
 
+
+typedef vector<ll> vl;
+namespace ignore {
+#include "../content/number-theory/ModPow.h"
+}
+ll modpow(ll a, ll e);
+#include "../content/numerical/NumberTheoreticTransform.h"
 ll modpow(ll a, ll e) {
 	if (e == 0) return 1;
 	ll x = modpow(a * a % mod, e >> 1);
 	return e & 1 ? x * a % mod : x;
 }
 
-typedef vector<ll> vl;
-void ntt(ll* x, ll* temp, ll* roots, int N, int skip) {
-	if (N == 1) return;
-	int n2 = N/2;
-	ntt(x     , temp, roots, n2, skip*2);
-	ntt(x+skip, temp, roots, n2, skip*2);
-	rep(i,0,N) temp[i] = x[i*skip];
-	rep(i,0,n2) {
-		ll s = temp[2*i], t = temp[2*i+1] * roots[skip*i];
-		x[skip*i] = (s + t) % mod; x[skip*(i+n2)] = (s - t) % mod;
-	}
-}
-void ntt(vl& x, bool inv = false) {
-	ll e = modpow(root, (mod-1) / sz(x));
-	if (inv) e = modpow(e, mod-2);
-	vl roots(sz(x), 1), temp = roots;
-	rep(i,1,sz(x)) roots[i] = roots[i-1] * e % mod;
-	ntt(&x[0], &temp[0], &roots[0], sz(x), 1);
-}
-vl conv(vl a, vl b) {
-	int s = sz(a) + sz(b) - 1; if (s <= 0) return {};
-	int L = s > 1 ? 32 - __builtin_clz(s - 1) : 0, n = 1 << L;
-	if ((rand()%2 == 0) && s <= 200) { // (factor 10 optimization for |a|,|b| = 10)
-		vl c(s);
-		rep(i,0,sz(a)) rep(j,0,sz(b))
-			c[i + j] = (c[i + j] + a[i] * b[j]) % mod;
-		trav(x, c) if (x < 0) x += mod;
-		return c;
-	}
-	a.resize(n); ntt(a);
-	b.resize(n); ntt(b);
-	vl c(n); ll d = modpow(n, mod-2);
-	rep(i,0,n) c[i] = a[i] * b[i] % mod * d % mod;
-	ntt(c, true); c.resize(s);
-	trav(x, c) if (x < 0) x += mod;
-	return c;
-}
 
 vl simpleConv(vl a, vl b) {
 	int s = sz(a) + sz(b) - 1;
-	if (s <= 0) return {};
+	if (a.empty() || b.empty()) return {};
 	vl c(s);
 	rep(i,0,sz(a)) rep(j,0,sz(b))
-		c[i+j] = (c[i+j] + a[i] * b[j]) % mod;
+		c[i+j] = (c[i+j] + (ll)a[i] * b[j]) % mod;
 	trav(x, c) if (x < 0) x += mod;
 	return c;
 }
@@ -83,10 +50,11 @@ int main() {
 	rep(it,0,6000) {
 		a.resize(ra() % 10);
 		b.resize(ra() % 10);
-		trav(x, a) x = ra() % 100 - 50;
-		trav(x, b) x = ra() % 100 - 50;
-		trav(x, simpleConv(a, b)) res += x * ind++ % mod;
-		trav(x, conv(a, b)) res2 += x * ind2++ % mod;
+		trav(x, a) x = (ra() % 100 - 50+mod)%mod;
+		trav(x, b) x = (ra() % 100 - 50+mod)%mod;
+		trav(x, simpleConv(a, b)) res += (ll)x * ind++ % mod;
+		trav(x, conv(a, b)) res2 += (ll)x * ind2++ % mod;
 	}
 	cout << res << ' ' << res2 << endl;
+    assert(res==res2);
 }


### PR DESCRIPTION
Since we rewrote the FFT and got a massive speedup, seems strange that the NTT has such a different implementation from the FFT.

This PR updates the NTT to be written in the style of the new FFT, and gets a 7-10x boost in performance from doing so: https://ideone.com/QJwGfE

This also includes an update to the fuzz test for ntt - A. because the new FFT implementation returns empty vector if either one of the input polynomials is empty, and that's the API I copied for the NTT, and B. because the new NTT now requires that all inputs be within the mod range.

This is still somewhat WIP - I have a couple questions/issues I need to investigate more (and some notes)
1. The conditional modular adds/subtracts add about 30% in performance UNLESS `O3` is enabled. If `O3` is enabled then it slows it down by about 50%. In this case, `O3` is harming the performance of the conditional modular adds/subtracts. It goes from about 200 ms to 450 ms with `O3`. I don't understand why, and I can't replicate it in an isolated example.

2. Is it possible to shorten this:
```cpp
    int curL = (mod - 1) >> 2;
    for (int k = 2; k < n; k *= 2) {
        int z[] = {1, modpow(root, curL)};
        curL >>= 1;
        rep(i, k, 2 * k) rt[i] = mul(rt[i / 2], z[i & 1]);
    }
```
3. Handling the output vector. It's currently handled in a redundant way, and I feel like it can be cleaned up nicely.

4. Re: the modular operations, it may be a good idea to inline them into the code (especially add/subtract since they're only used once).

I also need to test it more thoroughly, I'm not absolutely confident there's no issues with certain sizes and what not.