### PR TITLE
Added coloring to code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ To build KACTL, type `make kactl` (or `make fast`) on a \*NIX machine -- this wi
 kactl.pdf is to be kept to 25 pages + cover page.
 Occasionally the generated kactl.pdf is committed to the repo for convenience, but not too often because it makes git operations slower.
 
-Before printing KACTL for an official contest, you may want to locally change the arguments to `\team`, `\contest`, etc. in build/kactl.tex to something more fitting.
+Before printing KACTL for an official contest, you may want to locally change the arguments to `\team`, `\contest`, etc. in build/kactl.tex to something more fitting,
+You may also enable colored syntax highlighting in the same file.
 
 To upstream your changes, [send a pull request](https://help.github.com/articles/fork-a-repo/).
 

--- a/build/kactl.tex
+++ b/build/kactl.tex
@@ -6,6 +6,7 @@
 \team{Omogen Heap}{Simon Lindholm, Johan Sannemo, Mårten Wiman}
 % \contest{ACM-ICPC World Finals 2017}{May 24, 2017}
 \contest{\ }{\today}
+% \enablecolors
 
 \begin{document}
 	\maketeampage

--- a/build/kactlpkg.sty
+++ b/build/kactlpkg.sty
@@ -39,6 +39,12 @@
 	\def\@unilogo{#3}
 }
 
+\newcommand{\enablecolors}{
+	\lstset{commentstyle=\color{darkgray}\normalfont\itshape}
+	\lstset{keywordstyle=\color{myblue}}
+	\lstset{identifierstyle=\color{black}}
+}
+
 % Some default config
 \subtitle{{\tiny new}KACTL}
 \title{KTH ACM Contest Template Library}
@@ -170,13 +176,7 @@
 \lstset{showstringspaces=false}
 \lstset{breaklines=true}
 \lstset{basicstyle=\scriptsize\ttfamily}
-\if\PDFColor1
-    \lstset{commentstyle=\color{darkgray}\normalfont\itshape}
-    \lstset{keywordstyle=\color{myblue}}
-    \lstset{identifierstyle=\color{black}}
-\else
-    \lstset{commentstyle=\normalfont\itshape}
-\fi
+\lstset{commentstyle=\normalfont\itshape}
 \lstset{literate={^}{\caret}{1}}
 \lstset{literate={~}{\tilde}{1}}
 \lstset{emptylines=*1}

--- a/build/kactlpkg.sty
+++ b/build/kactlpkg.sty
@@ -158,6 +158,9 @@
 }
 \renewcommand*{\tilde}{\raise.17ex\hbox{$\scriptstyle\mathtt{\sim}$}}
 
+\definecolor{mygreen}{HTML}{007000}
+\definecolor{myblue}{HTML}{0000dd}
+
 % Configure source code listings
 \lstset{language=C++}
 \lstset{morekeywords={alignas,alignof}}
@@ -166,7 +169,9 @@
 \lstset{showstringspaces=false}
 \lstset{breaklines=true}
 \lstset{basicstyle=\scriptsize\ttfamily}
-\lstset{commentstyle=\normalfont\itshape}
+\lstset{commentstyle=\color{darkgray}\normalfont\itshape}
+\lstset{keywordstyle=\color{myblue}}
+\lstset{identifierstyle=\color{black}}
 \lstset{literate={^}{\caret}{1}}
 \lstset{literate={~}{\tilde}{1}}
 \lstset{emptylines=*1}

--- a/build/kactlpkg.sty
+++ b/build/kactlpkg.sty
@@ -42,6 +42,7 @@
 % Some default config
 \subtitle{{\tiny new}KACTL}
 \title{KTH ACM Contest Template Library}
+\newcommand{\PDFColor}{0}
 
 \def\today{\number\year-\ifthenelse{\number\month<10}{0}{}\number\month-\ifthenelse{\number\day<10}{0}{}\number\day} % Defines \today as YYYY-MM-DD
 
@@ -169,9 +170,13 @@
 \lstset{showstringspaces=false}
 \lstset{breaklines=true}
 \lstset{basicstyle=\scriptsize\ttfamily}
-\lstset{commentstyle=\color{darkgray}\normalfont\itshape}
-\lstset{keywordstyle=\color{myblue}}
-\lstset{identifierstyle=\color{black}}
+\if\PDFColor1
+    \lstset{commentstyle=\color{darkgray}\normalfont\itshape}
+    \lstset{keywordstyle=\color{myblue}}
+    \lstset{identifierstyle=\color{black}}
+\else
+    \lstset{commentstyle=\normalfont\itshape}
+\fi
 \lstset{literate={^}{\caret}{1}}
 \lstset{literate={~}{\tilde}{1}}
 \lstset{emptylines=*1}


### PR DESCRIPTION
Seems like it was just a simple matter of altering `\lstset`.

![image](https://user-images.githubusercontent.com/6355099/56508644-d3377100-64f2-11e9-8ac5-bc35ad9cf54c.png)

We might want to add a flag or change colors? Not sure how to do that/what colors we should choose.