### PR TITLE
Added hashing

### DIFF
--- a/build/kactlprocessor.py
+++ b/build/kactlprocessor.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 import sys
 import getopt
+import subprocess
 
 
 def escape(input):
@@ -128,6 +129,10 @@ def processwithcomments(caption, instream, outstream, listingslang = None):
         nsource = nsource.rstrip() + source[end:]
     nsource = nsource.strip()
 
+    hash_script = 'hash' if listingslang else 'hash-cpp'
+    p = subprocess.Popen(['sh', '../content/contest/%s.sh' % hash_script], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    hsh, _ = p.communicate(nsource)
+    hsh = hsh.split(None, 1)[0][:5]
     # Produce output
     out = []
     if warning:
@@ -147,7 +152,7 @@ def processwithcomments(caption, instream, outstream, listingslang = None):
         if includelist:
             out.append(r"\leftcaption{%s}" % pathescape(", ".join(includelist)))
         if nsource:
-            out.append(r"\rightcaption{%d lines}" % len(nsource.split("\n")))
+            out.append(r"\rightcaption{%s, %d lines}" % (hsh, len(nsource.split("\n"))))
         langstr = ", language="+listingslang if listingslang else ""
         out.append(r"\begin{lstlisting}[caption={%s}%s]" % (pathescape(caption), langstr))
         out.append(nsource)

--- a/build/kactlprocessor.py
+++ b/build/kactlprocessor.py
@@ -129,10 +129,10 @@ def processwithcomments(caption, instream, outstream, listingslang = None):
         nsource = nsource.rstrip() + source[end:]
     nsource = nsource.strip()
 
-    hash_script = 'hash' if listingslang else 'hash-cpp'
+    hash_script = 'hash'
     p = subprocess.Popen(['sh', '../content/contest/%s.sh' % hash_script], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     hsh, _ = p.communicate(nsource)
-    hsh = hsh.split(None, 1)[0][:5]
+    hsh = hsh.split(None, 1)[0]
     # Produce output
     out = []
     if warning:

--- a/content/contest/.vimrc
+++ b/content/contest/.vimrc
@@ -1,4 +1,6 @@
 set cin aw ai is ts=4 sw=4 tm=50 nu noeb bg=dark ru cul
 sy on   |   im jk <esc>   |   im kj <esc>   |   no ; :
-" Use for hashing parts of your file to verify no mistypes
-cmap H w !cpp -P -fpreprocessed \| tr -d '[:space:]' \| md5sum \| cut -c1-6
+" Select region and then type :H to hash your selection.
+" Useful for verifying that there aren't mistypes
+cmap H w !cpp -P -fpreprocessed \| tr -d '[:space:]' \
+ \| md5sum \| cut -c1-6

--- a/content/contest/.vimrc
+++ b/content/contest/.vimrc
@@ -1,4 +1,4 @@
 set cin aw ai is ts=4 sw=4 tm=50 nu noeb bg=dark ru cul
 sy on   |   im jk <esc>   |   im kj <esc>   |   no ; :
 
-com! -buffer -range=% Hash exe "<line1>,<line2>!cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-6" |y|sil u|echom @"
+com! -range=% Hash <line1>,<line2>w !cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-6

--- a/content/contest/.vimrc
+++ b/content/contest/.vimrc
@@ -1,5 +1,4 @@
 set cin aw ai is ts=4 sw=4 tm=50 nu noeb bg=dark ru cul
 sy on   |   im jk <esc>   |   im kj <esc>   |   no ; :
 
-com -range=% -nargs=1 P exe "<line1>,<line2>!".<q-args> |y|sil u|echom @"
-au FileType cpp com! -buffer -range=% Hash <line1>,<line2>P cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-5
+com! -buffer -range=% Hash exe "<line1>,<line2>!cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-6" |y|sil u|echom @"

--- a/content/contest/.vimrc
+++ b/content/contest/.vimrc
@@ -1,2 +1,5 @@
 set cin aw ai is ts=4 sw=4 tm=50 nu noeb bg=dark ru cul
 sy on   |   im jk <esc>   |   im kj <esc>   |   no ; :
+
+com -range=% -nargs=1 P exe "<line1>,<line2>!".<q-args> |y|sil u|echom @"
+au FileType cpp com! -buffer -range=% Hash <line1>,<line2>P cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-5

--- a/content/contest/.vimrc
+++ b/content/contest/.vimrc
@@ -1,4 +1,4 @@
 set cin aw ai is ts=4 sw=4 tm=50 nu noeb bg=dark ru cul
 sy on   |   im jk <esc>   |   im kj <esc>   |   no ; :
-
-com! -range=% Hash <line1>,<line2>w !cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-6
+" Use for hashing parts of your file to verify no mistypes
+cmap H w !cpp -P -fpreprocessed \| tr -d '[:space:]' \| md5sum \| cut -c1-6

--- a/content/contest/chapter.tex
+++ b/content/contest/chapter.tex
@@ -3,4 +3,5 @@
 \kactlimport[-l rawcpp]{template.cpp}
 \kactlimport[-l sh]{.bashrc}
 \kactlimport[-l raw]{.vimrc}
+\kactlimport[-l raw]{hash.sh}
 \kactlimport[-l raw]{troubleshoot.txt}

--- a/content/contest/hash-cpp.sh
+++ b/content/contest/hash-cpp.sh
@@ -1,0 +1,1 @@
+cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum

--- a/content/contest/hash-cpp.sh
+++ b/content/contest/hash-cpp.sh
@@ -1,1 +1,0 @@
-cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum

--- a/content/contest/hash.sh
+++ b/content/contest/hash.sh
@@ -1,0 +1,1 @@
+tr -d '[:space:]' | md5sum

--- a/content/contest/hash.sh
+++ b/content/contest/hash.sh
@@ -1,1 +1,1 @@
-tr -d '[:space:]' | md5sum
+cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-6

--- a/content/contest/hash.sh
+++ b/content/contest/hash.sh
@@ -1,1 +1,3 @@
+# Hashes a file, ignoring all whitespace and comments. Use for
+# verifying that code was correctly typed.
 cpp -P -fpreprocessed | tr -d '[:space:]' | md5sum | cut -c1-6


### PR DESCRIPTION
Done in a similar fashion to MIT's. Unlike MIT's, I elected to not do section hashing, and to simply hash everything that's printed.

Taking ecnerwala's suggestion, I believe I moved the hashing to the last pass of the preprocessor. I also decided to put first 5 chars of the hash in the header, which looks good imo.
![image](https://user-images.githubusercontent.com/6355099/56707021-3d176c80-66e5-11e9-8673-9c9fe6777f38.png)

Sometimes you can run into issues like this though: 
![image](https://user-images.githubusercontent.com/6355099/56707149-c038c280-66e5-11e9-9b22-65ddfcde28b6.png)

This might just be a quirk of my latex compilation, as it seems like it's possible for this to also overlap with the line number count as well.
