### PR TITLE
Added implementation of Dinic's

### DIFF
--- a/content/graph/Dinic.h
+++ b/content/graph/Dinic.h
@@ -7,45 +7,43 @@
  * On bipartite graphs the complexity is $O(\sqrt{V}E)$, and on unit graphs $O(\min(V^{1/2}, E^{2/3})E)).
  * Status: Tested on SPOJ FASTFLOW and SPOJ MATCHING
  */
-template<class T=int> struct Dinic {
-	const T INF = numeric_limits<T>::max();
-	struct edge {
+struct Dinic {
+	struct Edge {
 		int to, rev;
-		T c, f;
+		ll c, f;
 	};
-	vi lvl, ptr;
-	vector<vector<edge>> adj;
-	Dinic(int n) : lvl(n), ptr(n), adj(n) {}
-	void addEdge(int a, int b, T c, int rcap = 0) {
+	vi lvl, ptr, q;
+	vector<vector<Edge>> adj;
+	Dinic(int n) : lvl(n), ptr(n), q(n), adj(n) {}
+	void addEdge(int a, int b, ll c, int rcap = 0) {
 		adj[a].push_back({b, sz(adj[b]), c, 0});
 		adj[b].push_back({a, sz(adj[a]) - 1, rcap, 0});
 	}
-	T dfs(int v, T f, int t) {
+	ll dfs(int v, int t, ll f) {
 		if (v == t || !f) return f;
-		for (; ptr[v] < sz(adj[v]); ptr[v]++) {
-			edge &e = adj[v][ptr[v]];
-			if (lvl[e.to] != lvl[v] + 1) continue;
-			if (T p = dfs(e.to, min(f, e.c - e.f), t)) {
-				e.f += p, adj[e.to][e.rev].f -= p;
-				return p;
-			}
+		for (int& i = ptr[v]; i < sz(adj[v]); i++) {
+			Edge& e = adj[v][i];
+			if (lvl[e.to] == lvl[v] + 1)
+				if (ll p = dfs(e.to, t, min(f, e.c - e.f))) {
+					e.f += p, adj[e.to][e.rev].f -= p;
+					return p;
+				}
 		}
 		return 0;
 	}
 	ll calc(int s, int t) {
-		ll flow = 0;
-		while(true) {
-			fill(all(ptr), 0), fill(all(lvl), -1), lvl[s] = 0;
-			queue<int> q({s});
-			while (!q.empty() && lvl[t] == -1) {
-				int v = q.front();
-				q.pop();
+		ll flow = 0; q[0] = s;
+		do {
+			lvl = ptr = vi(sz(q));
+			int qi = 0, qe = lvl[s] = 1;
+			while (qi < qe && !lvl[t]) {
+				int v = q[qi++];
 				trav(e, adj[v])
-					if (lvl[e.to] == -1 && e.f < e.c)
-						q.push(e.to), lvl[e.to] = lvl[v] + 1;
+					if (!lvl[e.to] && e.f < e.c)
+						q[qe++] = e.to, lvl[e.to] = lvl[v] + 1;
 			}
-			if(lvl[t] == -1) return flow;
-			while (T p = dfs(s, INF, t)) flow += p;
-		}
+			while (ll p = dfs(s, t, LLONG_MAX)) flow += p;
+		} while (lvl[t]);
+		return flow;
 	}
 };

--- a/content/graph/Dinic.h
+++ b/content/graph/Dinic.h
@@ -22,17 +22,15 @@ struct Dinic {
 	}
 	ll dfs(int v, int t, ll f) {
 		if (v == t || !f) return f;
-		ll res = 0;
 		for (int& i = ptr[v]; i < sz(adj[v]); i++) {
 			Edge& e = adj[v][i];
 			if (lvl[e.to] == lvl[v] + 1)
 				if (ll p = dfs(e.to, t, min(f, e.c - e.f))) {
 					e.f += p, adj[e.to][e.rev].f -= p;
-					res += p, f -= p;
-					if (!f) break;
+					return p;
 				}
 		}
-		return res;
+		return 0;
 	}
 	ll calc(int s, int t) {
 		ll flow = 0; q[0] = s;

--- a/content/graph/Dinic.h
+++ b/content/graph/Dinic.h
@@ -22,15 +22,17 @@ struct Dinic {
 	}
 	ll dfs(int v, int t, ll f) {
 		if (v == t || !f) return f;
+		ll res = 0;
 		for (int& i = ptr[v]; i < sz(adj[v]); i++) {
 			Edge& e = adj[v][i];
 			if (lvl[e.to] == lvl[v] + 1)
 				if (ll p = dfs(e.to, t, min(f, e.c - e.f))) {
 					e.f += p, adj[e.to][e.rev].f -= p;
-					return p;
+					res += p, f -= p;
+					if (!f) break;
 				}
 		}
-		return 0;
+		return res;
 	}
 	ll calc(int s, int t) {
 		ll flow = 0; q[0] = s;

--- a/content/graph/Dinic.h
+++ b/content/graph/Dinic.h
@@ -1,0 +1,51 @@
+/**
+ * Author: chilli
+ * Date: 2019-04-26
+ * License: CC0
+ * Source: https://cp-algorithms.com/graph/dinic.html
+ * Description: Flow algorithm with guaranteed complexity $O(V^2E)$.
+ * On bipartite graphs the complexity is $O(\sqrt{V}E)$, and on unit graphs $O(\min(V^{1/2}, E^{2/3})E)).
+ * Status: Tested on SPOJ FASTFLOW and SPOJ MATCHING
+ */
+template<class T=int> struct Dinic {
+	const T INF = numeric_limits<T>::max();
+	struct edge {
+		int to, rev;
+		T c, f;
+	};
+	vi lvl, ptr;
+	vector<vector<edge>> adj;
+	Dinic(int n) : lvl(n), ptr(n), adj(n) {}
+	void addEdge(int a, int b, T c, int rcap = 0) {
+		adj[a].push_back({b, sz(adj[b]), c, 0});
+		adj[b].push_back({a, sz(adj[a]) - 1, rcap, 0});
+	}
+	T dfs(int v, T f, int t) {
+		if (v == t || !f) return f;
+		for (; ptr[v] < sz(adj[v]); ptr[v]++) {
+			edge &e = adj[v][ptr[v]];
+			if (lvl[e.to] != lvl[v] + 1) continue;
+			if (T p = dfs(e.to, min(f, e.c - e.f), t)) {
+				e.f += p, adj[e.to][e.rev].f -= p;
+				return p;
+			}
+		}
+		return 0;
+	}
+	ll calc(int s, int t) {
+		ll flow = 0;
+		while(true) {
+			fill(all(ptr), 0), fill(all(lvl), -1), lvl[s] = 0;
+			queue<int> q({s});
+			while (!q.empty() && lvl[t] == -1) {
+				int v = q.front();
+				q.pop();
+				trav(e, adj[v])
+					if (lvl[e.to] == -1 && e.f < e.c)
+						q.push(e.to), lvl[e.to] = lvl[v] + 1;
+			}
+			if(lvl[t] == -1) return flow;
+			while (T p = dfs(s, INF, t)) flow += p;
+		}
+	}
+};

--- a/content/graph/Dinic.h
+++ b/content/graph/Dinic.h
@@ -4,7 +4,8 @@
  * License: CC0
  * Source: https://cp-algorithms.com/graph/dinic.html
  * Description: Flow algorithm with guaranteed complexity $O(V^2E)$.
- * On bipartite graphs the complexity is $O(\sqrt{V}E)$, and on unit graphs $O(\min(V^{1/2}, E^{2/3})E)).
+ * $O(\sqrt{V}E)$ for bipartite graphs, $O(\min(V^{1/2}, E^{2/3})E))$ for unit graphs.
+ * To obtain the actual flow, look at positive values only.
  * Status: Tested on SPOJ FASTFLOW and SPOJ MATCHING
  */
 struct Dinic {

--- a/content/graph/chapter.tex
+++ b/content/graph/chapter.tex
@@ -12,6 +12,7 @@
 	\kactlimport{PushRelabel.h}
 	\kactlimport{MinCostMaxFlow.h}
 	\kactlimport{EdmondsKarp.h}
+	% \kactlimport{Dinic.h}
 	\kactlimport{MinCut.h}
 	\kactlimport{GlobalMinCut.h}
 


### PR DESCRIPTION
Comes in at 42 lines and 800 non-whitespace characters, compared to 36 lines and 592 non-whitespace characters for Edmonds-Karp, and 46 lines and 761 non-whitespace characters for Hopcroft-Karp. Note that about 4 of these lines and 100 of the characters are due to `addEdge` (whereas you need to add edges yourself for Edmonds-Karp).

Unluckily, it seems to run at `0.45` seconds on SPOJ MATCHING compared to `0.15` from Hopcroft-Karp... In addition, it doesn't return the matches themselves like Hopcroft-Karp it does.

For now I haven't included it in the document - I think that's another discussion. See #75 .