### PR TITLE
Standardized fuzztests for number theory code

### DIFF
--- a/content/number-theory/ModInverse.h
+++ b/content/number-theory/ModInverse.h
@@ -9,5 +9,5 @@
 #pragma once
 
 const ll mod = 1000000007, LIM = 200000;
-ll* inv = new ll[LIM] - 1; inv[1] = 1;
+vector<ll> inv(LIM); inv[1] = 1;
 rep(i,2,LIM) inv[i] = mod - (mod / i) * inv[mod % i] % mod;

--- a/content/number-theory/ModInverse.h
+++ b/content/number-theory/ModInverse.h
@@ -9,5 +9,6 @@
 #pragma once
 
 const ll mod = 1000000007, LIM = 200000;
-vector<ll> inv(LIM); inv[1] = 1;
+ll* inv = new ll[LIM] - 1; inv[1] = 1;
 rep(i,2,LIM) inv[i] = mod - (mod / i) * inv[mod % i] % mod;
+

--- a/fuzz-tests/number-theory/Eratosthenes.cpp
+++ b/fuzz-tests/number-theory/Eratosthenes.cpp
@@ -49,26 +49,8 @@ struct prime_sieve {
 						isprime[ii] &= (uchar)~(1<<ss);
 }	}		}	}	};
 
-// const int MAX_PR = 100000000;
-
-#if 1
 
 #include "../../content/number-theory/eratosthenes.h"
-
-#else
-
-bitset<MAX_PR> isprime;
-vi eratosthenes_sieve(int lim) {
-	isprime.set(); isprime[0] = isprime[1] = 0;
-	for (int i = 4; i < lim; i += 2) isprime[i] = 0;
-	for (int i = 3; i*i < lim; i += 2) if (isprime[i])
-		for (int j = i*i; j < lim; j += i*2) isprime[j] = 0;
-	vi pr;
-	rep(i,2,lim) if (isprime[i]) pr.push_back(i);
-	return pr;
-}
-
-#endif
 
 int main(int argc, char** argv) {
 	ll s = 0, s2 = 0;

--- a/fuzz-tests/number-theory/FracBinarySearch.cpp
+++ b/fuzz-tests/number-theory/FracBinarySearch.cpp
@@ -34,5 +34,6 @@ int main() {
 			assert(best.second == f.q);
 		}
 	}
+	cout<<"Tests passed!"<<endl;
 	return 0;
 }

--- a/fuzz-tests/number-theory/MillerRabin.cpp
+++ b/fuzz-tests/number-theory/MillerRabin.cpp
@@ -64,6 +64,8 @@ int main() {
 		n *= 1237618231ULL;
 		if (oldIsPrime(n) != isPrime(n)) {
 			cout << "differs from old for " << n << endl;
+			assert(false);
 		}
 	}
+	cout<<"Tests passed"<<endl;
 }

--- a/fuzz-tests/number-theory/ModInverse.cpp
+++ b/fuzz-tests/number-theory/ModInverse.cpp
@@ -9,7 +9,8 @@ typedef long long ll;
 typedef pair<int, int> pii;
 typedef vector<int> vi;
 
-const ll M = 1e9+7, LIM = 200000;
+const ll M = 1e9+7;
+ll LIM = 200000;
 
 bool isPrime(int x) {
 	if (x <= 1) return false;
@@ -22,14 +23,15 @@ bool isPrime(int x) {
 int ar[5] = {1,2,3,4,5};
 
 int main() {
-	vector<ll> inv(LIM, 1);
+	// vector<ll> inv(LIM, 1);
+
 	for (int M = 1; M <= 1000; ++M) {
+		#define mod=1000000007 /**/
+		#define ll /**/
+		#include "../../content/number-theory/ModInverse.h"
+		#undef mod
+		#undef ll
 		if (!isPrime(M)) continue;
-		inv.assign(LIM, 123123);
-		inv[0] = -1000;
-		inv[1] = 1;
-		rep(i,2,LIM)
-			inv[i] = M - (M / i) * inv[M % i] % M;
 		rep(i,0,M) {
 			bool works = (i * inv[i] % M == 1);
 			bool relp = (__gcd(i, M) == 1);
@@ -39,9 +41,3 @@ int main() {
 	cout<<"Tests pass!"<<endl;
 }
 
-ll inv[LIM] = {-10000, 1};
-int main2() {
-	rep(i,2,LIM) inv[i] = M - (M / i) * inv[M % i] % M;
-	cout << inv[0] << ' ' << inv[1] << ' ' << inv[2] << ' ' << inv[3] << endl;
-	return 0;
-}

--- a/fuzz-tests/number-theory/ModInverse.cpp
+++ b/fuzz-tests/number-theory/ModInverse.cpp
@@ -9,35 +9,16 @@ typedef long long ll;
 typedef pair<int, int> pii;
 typedef vector<int> vi;
 
-const ll M = 1e9+7;
-ll LIM = 200000;
-
-bool isPrime(int x) {
-	if (x <= 1) return false;
-	for (int i = 2; i*i <= x; ++i) {
-		if (x % i == 0) return false;
-	}
-	return true;
+ll modpow(ll a, ll e, ll mod) {
+	if (e == 0) return 1;
+	ll x = modpow(a * a % mod, e >> 1, mod);
+	return e & 1 ? x * a % mod : x;
 }
 
-int ar[5] = {1,2,3,4,5};
-
 int main() {
-	// vector<ll> inv(LIM, 1);
-
-	for (int M = 1; M <= 1000; ++M) {
-		#define mod=1000000007 /**/
-		#define ll /**/
-		#include "../../content/number-theory/ModInverse.h"
-		#undef mod
-		#undef ll
-		if (!isPrime(M)) continue;
-		rep(i,0,M) {
-			bool works = (i * inv[i] % M == 1);
-			bool relp = (__gcd(i, M) == 1);
-			assert(works == relp);
-		}
-	}
+	#include "../../content/number-theory/ModInverse.h"
+	for (int i=1; i<10000; i++)
+		assert(inv[i] == modpow(i, mod-2, mod));
 	cout<<"Tests pass!"<<endl;
 }
 

--- a/fuzz-tests/number-theory/ModInverse.cpp
+++ b/fuzz-tests/number-theory/ModInverse.cpp
@@ -36,6 +36,7 @@ int main() {
 			assert(works == relp);
 		}
 	}
+	cout<<"Tests pass!"<<endl;
 }
 
 ll inv[LIM] = {-10000, 1};

--- a/fuzz-tests/number-theory/ModSqrt.cpp
+++ b/fuzz-tests/number-theory/ModSqrt.cpp
@@ -29,4 +29,5 @@ int main() {
 		}
 next:;
 	}
+	cout<<"Tests passed!"<<endl;
 }

--- a/fuzz-tests/number-theory/ModSum.cpp
+++ b/fuzz-tests/number-theory/ModSum.cpp
@@ -44,7 +44,7 @@ void compare() {
 					ll b = modsum_naive(to, c, k, m);
 					if (a != b) {
 						cout << "differ! " << to << ' ' << c << ' ' << k << ' ' << m << ": " << a << " vs " << b << endl;
-						return;
+						assert(false);
 					}
 				}
 			}
@@ -61,7 +61,7 @@ void compare2() {
 					ll b = divsum_naive(to, c, k, m);
 					if (a != b) {
 						cout << "differ! " << to << ' ' << c << ' ' << k << ' ' << m << ": " << a << " vs " << b << endl;
-						return;
+						assert(false);
 					}
 				}
 			}
@@ -71,18 +71,14 @@ void compare2() {
 
 int main() {
 	compare(); compare2();
-	cout << modsum((ll)1e18, 1, 2, 3) << endl;
-	cout << (ll)1e18 << endl;
+	assert(modsum((ll)1e18, 1, 2, 3) == (ll)1e18);
 	rep(i,0,50) {
 		ll t = (ll)rand() << 3;
 		ll c = (ll)rand() << 2;
 		ll k = (ll)rand() << 2;
 		ll m = (ll)rand() >> 2;
-		cout << modsum(t, c, k, m) / (long double)(m/2 * t) << endl;
+		assert(abs(modsum(t, c, k, m) / ((long double)m/2 * t) - 1)<1e-5);
 	}
-	cout << modsum(1000000000000000000LL, 11231, 102917231231LL, 1236712312LL) << endl;
-	// rep(i,0,1000000) {
-		// modsum(1000000000000000000LL, 11231, 102917231231LL, 1236712312LL);
-	// }
+	cout<<"Tests passed!"<<endl;
 	return 0;
 }

--- a/fuzz-tests/number-theory/ModularArithmetic.cpp
+++ b/fuzz-tests/number-theory/ModularArithmetic.cpp
@@ -20,7 +20,10 @@ int main() {
 		assert((mc * mb).x == a);
 	}
 	Mod a = 2;
-	rep(i,0,17) {
-		cout << i << ": " << (a ^ i).x << endl;
+	ll cur=1;
+	rep(i, 0, 17) {
+		assert((a ^ i).x == cur);
+		cur = (cur * 2) % mod;
+		// cout << i << ": " << (a ^ i).x << endl;
 	}
 }

--- a/fuzz-tests/number-theory/ModularArithmetic.cpp
+++ b/fuzz-tests/number-theory/ModularArithmetic.cpp
@@ -26,4 +26,5 @@ int main() {
 		cur = (cur * 2) % mod;
 		// cout << i << ": " << (a ^ i).x << endl;
 	}
+	cout<<"Tests passed!"<<endl;
 }

--- a/fuzz-tests/number-theory/continuedfractions.cpp
+++ b/fuzz-tests/number-theory/continuedfractions.cpp
@@ -39,12 +39,3 @@ int main() {
 	cout<<"Tests passed!"<<endl;
 	return 0;
 }
-
-int main2() {
-	double x;
-	ll N = 1000000;
-	cin >> x >> N;
-	auto pa = approximate(x, N);
-	cout << pa.first << '/' << pa.second << endl;
-	return 0;
-}

--- a/fuzz-tests/number-theory/continuedfractions.cpp
+++ b/fuzz-tests/number-theory/continuedfractions.cpp
@@ -36,6 +36,7 @@ int main() {
 			assert(best.second == pa.second);
 		}
 	}
+	cout<<"Tests passed!"<<endl;
 	return 0;
 }
 

--- a/fuzz-tests/numerical/berlekampmassey.cpp
+++ b/fuzz-tests/numerical/berlekampmassey.cpp
@@ -64,6 +64,7 @@ int main() {
 		});
 		});
 	}
+	cout<<"Tests passed!"<<endl;
 	return 0;
 }
 


### PR DESCRIPTION
The only major change I made was to change the test for `modInverse.cpp`. Admittedly, I think the newer test is a weaker test than I was previously, but at least it automatically imports from `modInverse.h` now.

See #79.