### PR TITLE
Added green coloring for basicstyle

### DIFF
--- a/build/kactlpkg.sty
+++ b/build/kactlpkg.sty
@@ -40,6 +40,7 @@
 }
 
 \newcommand{\enablecolors}{
+	\lstset{basicstyle=\scriptsize\ttfamily\color{mygreen}}
 	\lstset{commentstyle=\color{darkgray}\normalfont\itshape}
 	\lstset{keywordstyle=\color{myblue}}
 	\lstset{identifierstyle=\color{black}}


### PR DESCRIPTION
Something about the coloring seemed off... 

I realized it was because I forgot to copy a line from the MIT's style file.

Current: 
![image](https://user-images.githubusercontent.com/6355099/56875306-0fe0fc00-6a0e-11e9-86da-4e38046e2b88.png)

After:
![image](https://user-images.githubusercontent.com/6355099/56875335-32731500-6a0e-11e9-8b44-6693096f0313.png)
