### PR TITLE
Updated policy hashmap with custom hash

### DIFF
--- a/content/data-structures/HashMap.h
+++ b/content/data-structures/HashMap.h
@@ -9,7 +9,16 @@
 #pragma once
 
 #include <bits/extc++.h> /** keep-include */
-__gnu_pbds::gp_hash_table<ll, int> h({},{},{},{}, {1 << 16});
+typedef unsigned long long ull;
+struct chash {
+    ull hash_f(ull x) {
+        x += 0x9e3779b97f4a7c15;
+        x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9;
+        x = (x ^ (x >> 27)) * 0x94d049bb133111eb;
+        return x ^ (x >> 31);
+    }
+};
+__gnu_pbds::gp_hash_table<ll, int, chash> h({},{},{},{}, {1 << 16});
 
 /** For CodeForces, or other places where hacking might be a problem:
 const int RANDOM = chrono::high_resolution_clock::now().time_since_epoch().count();

--- a/content/data-structures/HashMap.h
+++ b/content/data-structures/HashMap.h
@@ -9,16 +9,19 @@
 #pragma once
 
 #include <bits/extc++.h> /** keep-include */
-struct chash { // To use most bits rather than just the lowest ones:
-    const uint64_t C = ll(2e18 * M_PI) + 71; // large odd number
-    ll operator()(ll x) const { return __builtin_bswap64(x*C); }
+// To use most bits rather than just the lowest ones:
+struct chash {
+	const uint64_t C = ll(2e18 * M_PI) + 71; // large odd number
+	ll operator()(ll x) const { return __builtin_bswap64(x*C); }
 };
-__gnu_pbds::gp_hash_table<ll, int, chash> h({},{},{},{}, {1 << 16});
+__gnu_pbds::gp_hash_table<ll,int,chash> h({},{},{},{},{1<<16});
 
 /** For CodeForces, or other places where hacking might be a problem:
+
 const int RANDOM = chrono::high_resolution_clock::now().time_since_epoch().count();
-struct chash {
-    int operator()(ll x) const { return x + RANDOM; }
+struct chash { // To use most bits rather than just the lowest ones:
+	const uint64_t C = ll(2e18 * M_PI) + 71; // large odd number
+	ll operator()(ll x) const { return __builtin_bswap64((x^RANDOM)*C); }
 };
 __gnu_pbds::gp_hash_table<ll, int, chash> h({},{},{},{}, {1 << 16});
 */

--- a/content/data-structures/HashMap.h
+++ b/content/data-structures/HashMap.h
@@ -1,5 +1,5 @@
 /**
- * Author: Simon Lindholm
+ * Author: Simon Lindholm, chilli
  * Date: 2018-07-23
  * License: CC0
  * Source: http://codeforces.com/blog/entry/60737
@@ -9,21 +9,16 @@
 #pragma once
 
 #include <bits/extc++.h> /** keep-include */
-typedef unsigned long long ull;
-struct chash {
-    ull hash_f(ull x) {
-        x += 0x9e3779b97f4a7c15;
-        x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9;
-        x = (x ^ (x >> 27)) * 0x94d049bb133111eb;
-        return x ^ (x >> 31);
-    }
+struct chash { // To use most bits rather than just the lowest ones:
+    const uint64_t C = ll(2e18 * M_PI) + 71; // large odd number
+    ll operator()(ll x) const { return __builtin_bswap64(x*C); }
 };
 __gnu_pbds::gp_hash_table<ll, int, chash> h({},{},{},{}, {1 << 16});
 
 /** For CodeForces, or other places where hacking might be a problem:
 const int RANDOM = chrono::high_resolution_clock::now().time_since_epoch().count();
 struct chash {
-    int operator()(ll x) const { return x ^ RANDOM; }
+    int operator()(ll x) const { return x + RANDOM; }
 };
 __gnu_pbds::gp_hash_table<ll, int, chash> h({},{},{},{}, {1 << 16});
 */


### PR DESCRIPTION
See https://ideone.com/4frDuM.

```
8ms elapsed [custom hash insert]
2ms elapsed [custom hash read]
2847ms elapsed [no hash insert]
1701ms elapsed [no hash read]
```

It's a worst case example, of course, but it's a fairly natural one. I insert `v, v<<1, v<<2, ... v<<40`. We see a >300x slowdown for both insertions and reads (8/2ms to 2847/1701ms respectively).

I also have some discussion about it on the original post under "A better hash function".

I also don't think the custom preallocation is a big deal. Maybe it's worth including since it's not that much more, but my benchmarks don't show much of an improvement (maybe 5-10%).

Fixes #86 .