### PR TITLE
Updated CircleIntersection.h

### DIFF
--- a/content/geometry/CircleIntersection.h
+++ b/content/geometry/CircleIntersection.h
@@ -1,9 +1,8 @@
 /**
- * Author: Simon Lindholm, Victor Lecomte, chilli
+ * Author: Simon Lindholm
  * Date: 2015-09-01
  * License: CC0
- * Source: https://vlecomte.github.io/cp-geo.pdf
- * Description: Computes a pair of points at which two circles intersect. Returns false in case of no intersection.
+ * Description: Computes the pair of points at which two circles intersect. Returns false in case of no intersection.
  * Status: somewhat tested
  */
 #pragma once
@@ -11,13 +10,13 @@
 #include "Point.h"
 
 typedef Point<double> P;
-int circleInter(P a,P b,double r1,double r2,pair<P, P>* out){
+bool circleInter(P a,P b,double r1,double r2,pair<P, P>* out) {
 	if (a == b) { assert(r1 != r2); return false; }
-	P delta = b - a;
-	double d2 = delta.dist2(), p = (d2 + r1*r1 - r2*r2)/(d2*2);
-	double h2 = r1*r1 - p*p*d2;
-	if (h2 < 0) return false;
-	P mid = a + delta*p, per = delta.perp() * sqrt(h2 / d2);
+	P vec = b - a;
+	double d2 = vec.dist2(), sum = r1+r2, dif = r1-r2,
+	       p = (d2 + r1*r1 - r2*r2)/(d2*2), h2 = r1*r1 - p*p*d2;
+	if (sum*sum < d2 || dif*dif > d2) return false;
+	P mid = a + vec*p, per = vec.perp() * sqrt(fmax(0, h2) / d2);
 	*out = {mid + per, mid - per};
 	return true;
 }

--- a/content/geometry/CircleIntersection.h
+++ b/content/geometry/CircleIntersection.h
@@ -1,8 +1,8 @@
 /**
- * Author: Simon Lindholm
+ * Author: Simon Lindholm, Victor Lecomte, chilli
  * Date: 2015-09-01
  * License: CC0
- * Description: Computes a pair of points at which two circles intersect. Returns false in case of no intersection.
+ * Description: Computes a pair of points at which two circles intersect. Returns number of intersections. If intersection is only at one point then that point is returned twice.
  * Status: somewhat tested
  */
 #pragma once
@@ -10,16 +10,13 @@
 #include "Point.h"
 
 typedef Point<double> P;
-bool circleIntersection(P a, P b, double r1, double r2,
-		pair<P, P>* out) {
-	P delta = b - a;
-	assert(delta.x || delta.y || r1 != r2);
-	if (!delta.x && !delta.y) return false;
-	double r = r1 + r2, d2 = delta.dist2();
+int circleInter(P a,P b,double r1,double r2,pair<P, P>& out){
+	P delta = b - a; double d2 = delta.dist2();
+	if (d2 == 0) { assert(r1 != r2); return 0; }
 	double p = (d2 + r1*r1 - r2*r2) / (2.0 * d2);
 	double h2 = r1*r1 - p*p*d2;
-	if (d2 > r*r || h2 < 0) return false;
+	if (h2 < 0) return 0;
 	P mid = a + delta*p, per = delta.perp() * sqrt(h2 / d2);
-	*out = {mid + per, mid - per};
-	return true;
+	out = {mid + per, mid - per};
+	return 1 + sgn(h2);
 }

--- a/content/geometry/CircleIntersection.h
+++ b/content/geometry/CircleIntersection.h
@@ -2,7 +2,8 @@
  * Author: Simon Lindholm, Victor Lecomte, chilli
  * Date: 2015-09-01
  * License: CC0
- * Description: Computes a pair of points at which two circles intersect. Returns number of intersections. If intersection is only at one point then that point is returned twice.
+ * Source: https://vlecomte.github.io/cp-geo.pdf
+ * Description: Computes a pair of points at which two circles intersect. Returns false in case of no intersection.
  * Status: somewhat tested
  */
 #pragma once
@@ -10,13 +11,13 @@
 #include "Point.h"
 
 typedef Point<double> P;
-int circleInter(P a,P b,double r1,double r2,pair<P, P>& out){
-	P delta = b - a; double d2 = delta.dist2();
-	if (d2 == 0) { assert(r1 != r2); return 0; }
-	double p = (d2 + r1*r1 - r2*r2) / (2.0 * d2);
+int circleInter(P a,P b,double r1,double r2,pair<P, P>* out){
+	if (a == b) { assert(r1 != r2); return false; }
+	P delta = b - a;
+	double d2 = delta.dist2(), p = (d2 + r1*r1 - r2*r2)/(d2*2);
 	double h2 = r1*r1 - p*p*d2;
-	if (h2 < 0) return 0;
+	if (h2 < 0) return false;
 	P mid = a + delta*p, per = delta.perp() * sqrt(h2 / d2);
-	out = {mid + per, mid - per};
-	return 1 + sgn(h2);
+	*out = {mid + per, mid - per};
+	return true;
 }

--- a/content/geometry/CircleIntersection.h
+++ b/content/geometry/CircleIntersection.h
@@ -3,7 +3,7 @@
  * Date: 2015-09-01
  * License: CC0
  * Description: Computes the pair of points at which two circles intersect. Returns false in case of no intersection.
- * Status: somewhat tested
+ * Status: fuzz-tested
  */
 #pragma once
 

--- a/fuzz-tests/geometry/CircleIntersection.cpp
+++ b/fuzz-tests/geometry/CircleIntersection.cpp
@@ -1,0 +1,77 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+#define rep(i, a, b) for(int i = a; i < (b); ++i)
+#define trav(a, x) for(auto& a : x)
+#define all(x) x.begin(), x.end()
+#define sz(x) (int)(x).size()
+typedef long long ll;
+typedef pair<int, int> pii;
+typedef vector<int> vi;
+
+#include "../../content/geometry/CircleIntersection.h"
+
+int main() {
+	cin.sync_with_stdio(0); cin.tie(0);
+	cin.exceptions(cin.failbit);
+	srand(2);
+	rep(it,0,100000) {
+		double rnd[6];
+		rep(i,0,6)
+			rnd[i] = rand() % 21 - 10;
+		P a(rnd[0], rnd[1]);
+		P b(rnd[2], rnd[3]);
+		double ra = rand() % 10;
+		double rb = rand() % 10;
+		if (a == b) continue;
+		pair<P, P> out;
+		bool ret = circleInter(a, b, ra, rb, &out);
+		if (ret) {
+			// cout << (out.first - a).dist() << ' ' << ra << endl;
+			// cout << ((out.first - a).dist() - ra) << endl;
+			assert(abs((out.first - a).dist() - ra) < 1e-9);
+			assert(abs((out.second - a).dist() - ra) < 1e-9);
+			assert(abs((out.first - b).dist() - rb) < 1e-9);
+			assert(abs((out.second - b).dist() - rb) < 1e-9);
+		}
+
+		// Hill-climb the answer
+		auto func = [&](P x) {
+			double d1 = (x - a).dist() - ra;
+			double d2 = (x - b).dist() - rb;
+			return d1*d1 + d2*d2;
+		};
+		P start = (a + b) / 2 + (a - b).perp();
+		pair<double, P> cur(func(start), start);
+		for (double jmp = 100; jmp > 1e-20; jmp /= 2) {
+			int iters = 0;
+			for (int imp = 1; imp--;) {
+				if (++iters == 100) goto skip;
+				rep(dx,-1,2) rep(dy,-1,2) {
+					P p = cur.second;
+					p.x += dx*jmp;
+					p.y += dy*jmp;
+					pair<double, P> np{func(p), p};
+					if (np < cur) cur = np, imp = 1;
+				}
+			}
+		}
+
+		if (abs((cur.second - a).dist() - ra) < 1e-9 &&
+		    abs((cur.second - b).dist() - rb) < 1e-9) {
+			assert(ret);
+			// cout << out.second.x << ' ' << out.second.y << endl;
+			assert((out.first - cur.second).dist() < 1e-6 || (out.second - cur.second).dist() < 1e-6);
+		} else {
+			// cout << a.x << ' ' << a.y << ' ' << b.x << ' ' << b.y << ' ' << ra << ' ' << rb << endl;
+			// cout << cur.second.x << ' ' << cur.second.y << endl;
+			assert(!ret);
+		}
+
+		// cerr << '.';
+		continue;
+skip:;
+		// Sometimes hill-climbing is slow, for some reason. :(
+		// cerr << '#';
+	}
+}

--- a/fuzz-tests/geometry/CircleIntersection.cpp
+++ b/fuzz-tests/geometry/CircleIntersection.cpp
@@ -27,8 +27,6 @@ int main() {
 		pair<P, P> out;
 		bool ret = circleInter(a, b, ra, rb, &out);
 		if (ret) {
-			// cout << (out.first - a).dist() << ' ' << ra << endl;
-			// cout << ((out.first - a).dist() - ra) << endl;
 			assert(abs((out.first - a).dist() - ra) < 1e-9);
 			assert(abs((out.second - a).dist() - ra) < 1e-9);
 			assert(abs((out.first - b).dist() - rb) < 1e-9);
@@ -60,11 +58,8 @@ int main() {
 		if (abs((cur.second - a).dist() - ra) < 1e-9 &&
 		    abs((cur.second - b).dist() - rb) < 1e-9) {
 			assert(ret);
-			// cout << out.second.x << ' ' << out.second.y << endl;
 			assert((out.first - cur.second).dist() < 1e-6 || (out.second - cur.second).dist() < 1e-6);
 		} else {
-			// cout << a.x << ' ' << a.y << ' ' << b.x << ' ' << b.y << ' ' << ra << ' ' << rb << endl;
-			// cout << cur.second.x << ' ' << cur.second.y << endl;
 			assert(!ret);
 		}
 
@@ -74,4 +69,5 @@ skip:;
 		// Sometimes hill-climbing is slow, for some reason. :(
 		// cerr << '#';
 	}
+	cout<<"Tests passed!"<<endl;
 }


### PR DESCRIPTION
3 main changes. I didn't understand why any of these existed in the first place so if there's a reason, I'll revert that change from this PR: 
1. Changed the API to return 0/1/2 depending on the number of intersection points. Currently, the function doesn't distinguish between 1 and 2 return points. I suppose this is the equivalent of testing for `strict` in functions like `inPolygon`.
2. Changed `out` from a pointer to a reference.
3. Removed the `d2 > r*r` check.  Is this check here for higher precision?