### PR TITLE
Change x.begin() to begin(x)

### DIFF
--- a/content/contest/template.cpp
+++ b/content/contest/template.cpp
@@ -3,7 +3,7 @@ using namespace std;
 
 #define rep(i, a, b) for(int i = a; i < (b); ++i)
 #define trav(a, x) for(auto& a : x)
-#define all(x) x.begin(), x.end()
+#define all(x) begin(x), end(x)
 #define sz(x) (int)(x).size()
 typedef long long ll;
 typedef pair<int, int> pii;


### PR DESCRIPTION
`begin(x)` is a strict superset of what `x.begin()` can do.

See https://stackoverflow.com/questions/26290316/difference-between-vectorbegin-and-stdbegin

I realize that KACTL almost never uses C-style arrays, but we also save 2 characters from this :^)