### PR TITLE
Moved minimum vertex cover next to bipartite matching

### DIFF
--- a/content/graph/chapter.tex
+++ b/content/graph/chapter.tex
@@ -19,9 +19,9 @@
 \section{Matching}
 	\kactlimport{hopcroftKarp.h}
 	\kactlimport{DFSMatching.h}
+	\kactlimport{MinimumVertexCover.h}
 	\kactlimport{WeightedMatching.h}
 	\kactlimport{GeneralMatching.h}
-	\kactlimport{MinimumVertexCover.h}
 
 \section{DFS algorithms}
 	\kactlimport{SCC.h}


### PR DESCRIPTION
2 reasons:
1. MinimumVertexCover depends on the bipartite matching algorithms.
1. I think it makes more sense to put the bipartite matching stuff together, before the general graph matching.