### PR TITLE
Segment improvements

### DIFF
--- a/content/data-structures/SegmentTree.h
+++ b/content/data-structures/SegmentTree.h
@@ -3,7 +3,7 @@
  * Date: 2017-10-31
  * License: CC0
  * Source: folklore
- * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, LOW and f.
+ * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, NEUTRAL and f.
  * Time: O(\log N)
  * Status: fuzz-tested
  */
@@ -11,7 +11,7 @@
 
 struct Tree {
 	typedef int T;
-	static const T LOW = INT_MIN;
+	static const T NEUTRAL = INT_MIN;
 	T f(T a, T b) { return max(a, b); } // (any associative fn)
 	vector<T> s; int n;
 	Tree(int n = 0, T def = 0) : s(2*n, def), n(n) {}
@@ -20,7 +20,7 @@ struct Tree {
 			s[pos / 2] = f(s[pos & ~1], s[pos | 1]);
 	}
 	T query(int b, int e) { // query [b, e)
-		T ra = LOW, rb = LOW;
+		T ra = NEUTRAL, rb = NEUTRAL;
 		for (b += n, e += n; b < e; b /= 2, e /= 2) {
 			if (b % 2) ra = f(ra, s[b++]);
 			if (e % 2) rb = f(s[--e], rb);

--- a/content/data-structures/SegmentTree.h
+++ b/content/data-structures/SegmentTree.h
@@ -3,7 +3,7 @@
  * Date: 2017-10-31
  * License: CC0
  * Source: folklore
- * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, NEUTRAL and f.
+ * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, NEU and f.
  * Time: O(\log N)
  * Status: fuzz-tested
  */
@@ -11,16 +11,16 @@
 
 struct Tree {
 	typedef int T;
-	static constexpr T NEUTRAL = INT_MIN;
+	static constexpr T NEU = INT_MIN;
 	T f(T a, T b) { return max(a, b); } // (any associative fn)
 	vector<T> s; int n;
-	Tree(int n = 0, T def = NEUTRAL) : s(2*n, def), n(n) {}
+	Tree(int n = 0, T def = NEU) : s(2*n, def), n(n) {}
 	void update(int pos, T val) {
 		for (s[pos += n] = val; pos > 1; pos /= 2)
 			s[pos / 2] = f(s[pos & ~1], s[pos | 1]);
 	}
 	T query(int b, int e) { // query [b, e)
-		T ra = NEUTRAL, rb = NEUTRAL;
+		T ra = NEU, rb = NEU;
 		for (b += n, e += n; b < e; b /= 2, e /= 2) {
 			if (b % 2) ra = f(ra, s[b++]);
 			if (e % 2) rb = f(s[--e], rb);

--- a/content/data-structures/SegmentTree.h
+++ b/content/data-structures/SegmentTree.h
@@ -11,7 +11,7 @@
 
 struct Tree {
 	typedef int T;
-	static const T NEUTRAL = INT_MIN;
+	static constexpr T NEUTRAL = INT_MIN;
 	T f(T a, T b) { return max(a, b); } // (any associative fn)
 	vector<T> s; int n;
 	Tree(int n = 0, T def = NEUTRAL) : s(2*n, def), n(n) {}

--- a/content/data-structures/SegmentTree.h
+++ b/content/data-structures/SegmentTree.h
@@ -14,7 +14,7 @@ struct Tree {
 	static const T NEUTRAL = INT_MIN;
 	T f(T a, T b) { return max(a, b); } // (any associative fn)
 	vector<T> s; int n;
-	Tree(int n = 0, T def = 0) : s(2*n, def), n(n) {}
+	Tree(int n = 0, T def = NEUTRAL) : s(2*n, def), n(n) {}
 	void update(int pos, T val) {
 		for (s[pos += n] = val; pos > 1; pos /= 2)
 			s[pos / 2] = f(s[pos & ~1], s[pos | 1]);

--- a/content/data-structures/SegmentTree.h
+++ b/content/data-structures/SegmentTree.h
@@ -3,7 +3,7 @@
  * Date: 2017-10-31
  * License: CC0
  * Source: folklore
- * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, NEU and f.
+ * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, f and unit.
  * Time: O(\log N)
  * Status: fuzz-tested
  */
@@ -11,16 +11,16 @@
 
 struct Tree {
 	typedef int T;
-	static constexpr T NEU = INT_MIN;
+	static constexpr T unit = INT_MIN;
 	T f(T a, T b) { return max(a, b); } // (any associative fn)
 	vector<T> s; int n;
-	Tree(int n = 0, T def = NEU) : s(2*n, def), n(n) {}
+	Tree(int n = 0, T def = unit) : s(2*n, def), n(n) {}
 	void update(int pos, T val) {
 		for (s[pos += n] = val; pos > 1; pos /= 2)
 			s[pos / 2] = f(s[pos & ~1], s[pos | 1]);
 	}
 	T query(int b, int e) { // query [b, e)
-		T ra = NEU, rb = NEU;
+		T ra = unit, rb = unit;
 		for (b += n, e += n; b < e; b /= 2, e /= 2) {
 			if (b % 2) ra = f(ra, s[b++]);
 			if (e % 2) rb = f(s[--e], rb);


### PR DESCRIPTION
Using `NEUTRAL` instead of `LOW` makes the code more clear when using a different function.