### PR TITLE
Make the TOC clickable

### DIFF
--- a/content/tex/kactlpkg.sty
+++ b/content/tex/kactlpkg.sty
@@ -19,6 +19,7 @@
 \usepackage[parfill]{parskip}           % For compact enumerations
 \usepackage[dvipsnames]{xcolor}
 \usepackage[normalem]{ulem}
+\usepackage[hidelinks]{hyperref}        % For clickable table of contents
 
 % Config commands
 \newcommand{\subtitle}[1]{


### PR DESCRIPTION
For my own purely selfish reasons (ie: it's convenient for me to navigate through the pdf by clicking on it).

Otherwise it looks the same I believe.