### PR TITLE
Changes to Aho-Corasick

### DIFF
--- a/content/strings/AhoCorasick.h
+++ b/content/strings/AhoCorasick.h
@@ -3,68 +3,67 @@
  * Date: 2015-02-18
  * License: CC0
  * Source: marian's (TC) code
- * Description: Aho-Corasick tree is used for multiple pattern matching.
- * Initialize the tree with create(patterns). find(word) returns for each position
- * the index of the longest word that ends there, or -1 if none. findAll(\_, word) finds all words
- * (up to $N \sqrt N$ many if no duplicate patterns) that start at each position (shortest first).
+ * Description: Aho-Corasick automaton, used for multiple pattern matching.
+ * Initialize the automaton with create(patterns); the automaton start node will be at index 1.
+ * find(word) returns for each position the index of the longest word that ends there, or -1 if none.
+ * findAll(\_, word) finds all words (up to $N \sqrt N$ many if no duplicate patterns)
+ * that start at each position (shortest first).
  * Duplicate patterns are allowed; empty patterns are not.
  * To find the longest words that start at each position, reverse all input.
+ * For large alphabets, split each symbol into chunk, with sentinel bits for symbol boundaries.
  * Time: create is $O(26N)$ where $N$ is the sum of length of patterns.
  * find is $O(M)$ where $M$ is the length of the word. findAll is $O(NM)$.
- * Status: lightly tested
+ * Status: fuzz-tested
  */
 #pragma once
 
 struct AhoCorasick {
-	enum {alpha = 26, first = 'A'};
+	enum {alpha = 26, first = 'A'}; // change this!
 	struct Node {
 		// (nmatches is optional)
-		int back, next[alpha], start = -1, end = -1, nmatches = 0;
-		Node(int v) { memset(next, v, sizeof(next)); }
+		int back, next[alpha]{}, pat = -1, t = -1, nmatches = 0;
+		void p(int y, vi& L) { t = (pat == -1 ? pat : L[t]) = y; }
 	};
 	vector<Node> N;
-	vector<int> backp;
+	vi backp;
 	void insert(string& s, int j) {
 		assert(!s.empty());
-		int n = 0;
+		int n = 1;
 		trav(c, s) {
 			int& m = N[n].next[c - first];
-			if (m == -1) { n = m = sz(N); N.emplace_back(-1); }
-			else n = m;
+			if (m) n = m;
+			else { n = m = sz(N); N.emplace_back(); }
 		}
-		if (N[n].end == -1) N[n].start = j;
-		backp.push_back(N[n].end);
-		N[n].end = j;
+		backp.push_back(0);
+		N[n].p(j, backp);
 		N[n].nmatches++;
 	}
-	AhoCorasick(vector<string>& pat) {
-		N.emplace_back(-1);
+	AhoCorasick(vector<string>& pat) : N(2) {
+		rep(i,0,alpha) N[0].next[i] = 1;
+		N[1].back = 0;
 		rep(i,0,sz(pat)) insert(pat[i], i);
-		N[0].back = sz(N);
-		N.emplace_back(0);
 
-		queue<int> q;
-		for (q.push(0); !q.empty(); q.pop()) {
-			int n = q.front(), prev = N[n].back;
+		vi q(sz(N)); int qe = q[0] = 1;
+		rep(qi,0,qe) {
+			int n = q[qi], prev = N[n].back;
 			rep(i,0,alpha) {
 				int &ed = N[n].next[i], y = N[prev].next[i];
-				if (ed == -1) ed = y;
+				if (!ed) ed = y;
 				else {
 					N[ed].back = y;
-					(N[ed].end == -1 ? N[ed].end : backp[N[ed].start])
-						= N[y].end;
+					N[ed].p(N[y].pat, backp);
 					N[ed].nmatches += N[y].nmatches;
-					q.push(ed);
+					q[qe++] = ed;
 				}
 			}
 		}
 	}
 	vi find(string word) {
-		int n = 0;
+		int n = 1;
 		vi res; // ll count = 0;
 		trav(c, word) {
 			n = N[n].next[c - first];
-			res.push_back(N[n].end);
+			res.push_back(N[n].pat);
 			// count += N[n].nmatches;
 		}
 		return res;

--- a/fuzz-tests/strings/AhoCorasick.cpp
+++ b/fuzz-tests/strings/AhoCorasick.cpp
@@ -1,0 +1,90 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+#define rep(i, a, b) for(int i = a; i < int(b); ++i)
+#define trav(a, v) for(auto& a : v)
+#define all(x) x.begin(), x.end()
+#define sz(x) (int)(x).size()
+
+typedef long long ll;
+typedef pair<int, int> pii;
+typedef vector<int> vi;
+
+#include "../../content/strings/AhoCorasick.h"
+
+template<class F>
+void gen(string& s, int at, int alpha, F f) {
+	if (at == sz(s)) f();
+	else {
+		rep(i,0,alpha) {
+			s[at] = (char)('A' + i);
+			gen(s, at+1, alpha, f);
+		}
+	}
+}
+
+void test(const string& s) {
+	vector<string> pats;
+	string cur;
+	rep(i,0,sz(s)) {
+		if (s[i] == 'A') {
+			pats.push_back(cur);
+			cur = "";
+		}
+		else cur += s[i];
+	}
+
+	string hay = cur;
+	trav(x, pats) if (x.empty()) return;
+
+	// Priority order of patterns for findAll: shorter patterns first, tie-broken by index
+	vi order(sz(pats));
+	iota(all(order), 0);
+	stable_sort(all(order), [&](int a, int b) { return sz(pats[a]) < sz(pats[b]); });
+
+	AhoCorasick ac(pats);
+	vector<vi> positions = ac.findAll(pats, hay);
+
+	vi ord;
+	rep(i,0,sz(hay)) {
+		ord.clear();
+		trav(j, order) {
+			string& pat = pats[j];
+			if (hay.substr(i, pat.size()) == pat) {
+				ord.push_back(j);
+			}
+		}
+
+		if (positions[i] != ord) {
+			cerr << "failed!" << endl;
+			cerr << hay << endl;
+			trav(x, pats) cerr << x << endl;
+			cerr << "failed at position " << i << endl;
+			cerr << "got:" << endl;
+			trav(x, positions[i]) cerr << x << ' ';
+			cerr << endl;
+			cerr << "expected:" << endl;
+			trav(x, ord) cerr << x << ' ';
+			cerr << endl;
+			abort();
+		}
+	}
+}
+
+int main() {
+	// test ~4^11 strings
+	rep(n,0,12) {
+		string s(n, 'x');
+		gen(s, 0, 4, [&]() {
+			test(s);
+		});
+	}
+	// then ~5^8
+	rep(n,0,9) {
+		string s(n, 'x');
+		gen(s, 0, 5, [&]() {
+			test(s);
+		});
+	}
+	cout<<"Tests passed!"<<endl;
+}


### PR DESCRIPTION
I thought I needed an Aho-Corasick with map instead of array to support large alphabets, and started working on some changes to that effect (mostly defaulting to 0 instead of -1 for non-existent trie entries). Turns out I don't know how to make the tree post-processing step work without filling in all entries; the best idea I have so far is to give up on maps and instead split symbols into chunks, with markers for initial chunks.

Some of the changes here are probably useful, but swapping back to 0/-1 may be good (1 is an unnatural starting index, and memset is faster than normal array initialization on GCC). Either way, I'm dropping this for now and making a PR as a reminder for later.