### PR TITLE
Added fast input

### DIFF
--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -1,0 +1,33 @@
+/**
+ * Author: chilli
+ * License: CC0
+ * Source:
+ * Description: Reads in arbitrary amounts of integral values.
+ * Status: tested on SPOJ INTEST
+ * Time: About 3x as fast as cin.
+ * Usage: int a, b[5]; ll c;
+ * read_int(a, b[0], c);
+ */
+#pragma once
+
+struct GC {
+    char buf[1 << 16 | 1];
+    int bc = 0, be = 0;
+    char operator()() {
+        if (bc >= be) {
+            be = fread(buf, 1, sizeof(buf) - 1, stdin);
+            buf[be] = bc = 0;
+        }
+        return buf[bc++];
+    }
+} gc;
+void read_int() {}
+template <class T, class... S>
+inline void read_int(T &a, S &... b) {
+	char c, s = 1;
+	while (isspace(c = gc()));
+	if (c == '-') s = -1, c = gc();
+	for (a = c - '0'; isdigit(c = gc()); a = a * 10 + c - '0');
+	a *= s;
+	read_int(b...);
+}

--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -2,32 +2,29 @@
  * Author: chilli
  * License: CC0
  * Source:
- * Description: Reads in arbitrary amounts of integral values.
+ * Description: Returns an integer. Usage requires your program to pipe in input from file.
  * Status: tested on SPOJ INTEST
- * Time: About 5x as fast as cin.
- * Usage: int a, b[5]; ll c;
- * read_int(a, b[0], c);
+ * Time: About 5x as fast as cin/scanf.
+ * Usage: ./a.out < input.txt
  */
 #pragma once
 
 struct GC {
-    char buf[1 << 16 | 1];
-    int bc = 0, be = 0;
-    char operator()() {
-        if (bc >= be) {
-            be = fread(buf, 1, sizeof(buf) - 1, stdin);
-            buf[be] = bc = 0;
-        }
-        return buf[bc++];
-    }
+	char buf[1 << 16 | 1];
+	int bc = 0, be = 0;
+	char operator()() {
+		if (bc >= be) {
+			be = fread(buf, 1, sizeof(buf) - 1, stdin);
+			buf[be] = bc = 0;
+		}
+		return buf[bc++];
+	}
 } gc;
-void read_int() {}
-template <class T, class... S>
-inline void read_int(T &a, S &... b) {
-	char c, s = 1;
-	while (isspace(c = gc()));
-	if (c == '-') s = -1, c = gc();
-	for (a = c - '0'; isdigit(c = gc()); a = a * 10 + c - '0');
-	a *= s;
-	read_int(b...);
+inline int read_int() {
+	static char c;
+	while ((c = gc()) < 40);
+	if (c == '-') return -read_int();
+	int a = c - '0';
+	for (; isdigit(c = gc()); a = a * 10 + c - '0');
+	return a;
 }

--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -12,17 +12,17 @@
 #pragma once
 
 struct GC {
-	char buf[1 << 16 | 1];
+	char buf[1 << 16];
 	int bc = 0, be = 0;
 	char operator()() {
 		if (bc >= be) {
-			be = fread(buf, 1, sizeof(buf) - 1, stdin);
-			buf[be] = bc = 0;
+			buf[0] = bc = 0;
+			be = fread(buf, 1, sizeof(buf), stdin);
 		}
 		return buf[bc++]; // returns 0 on EOF
 	}
 } gc;
-inline int read_int() {
+int read_int() {
 	char c;
 	while ((c = gc()) < 40);
 	if (c == '-') return -read_int();

--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -23,10 +23,10 @@ struct GC {
 	}
 } gc;
 inline int read_int() {
-	static char c;
+	char c;
 	while ((c = gc()) < 40);
 	if (c == '-') return -read_int();
 	int a = c - '0';
-	for (; isdigit(c = gc()); a = a * 10 + c - '0');
+	while (isdigit(c = gc())) a = a * 10 + c -'0';
 	return a;
 }

--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -2,7 +2,9 @@
  * Author: chilli
  * License: CC0
  * Source:
- * Description: Returns an integer. Usage requires your program to pipe in input from file.
+ * Description: Returns an integer. Usage requires your program to pipe in
+ * input from file. Can replace calls to gc() with getchar_unlocked() if extra
+ * speed isn't necessary (60% slowdown).
  * Status: tested on SPOJ INTEST
  * Time: About 5x as fast as cin/scanf.
  * Usage: ./a.out < input.txt
@@ -17,7 +19,7 @@ struct GC {
 			be = fread(buf, 1, sizeof(buf) - 1, stdin);
 			buf[be] = bc = 0;
 		}
-		return buf[bc++];
+		return buf[bc++]; // returns 0 on EOF
 	}
 } gc;
 inline int read_int() {

--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -1,7 +1,7 @@
 /**
  * Author: chilli
  * License: CC0
- * Source:
+ * Source: Own work
  * Description: Returns an integer. Usage requires your program to pipe in
  * input from file. Can replace calls to gc() with getchar_unlocked() if extra
  * speed isn't necessary (60% slowdown).

--- a/content/various/FastInput.h
+++ b/content/various/FastInput.h
@@ -4,7 +4,7 @@
  * Source:
  * Description: Reads in arbitrary amounts of integral values.
  * Status: tested on SPOJ INTEST
- * Time: About 3x as fast as cin.
+ * Time: About 5x as fast as cin.
  * Usage: int a, b[5]; ll c;
  * read_int(a, b[0], c);
  */

--- a/content/various/chapter.tex
+++ b/content/various/chapter.tex
@@ -37,6 +37,7 @@
 			\item \lstinline{#pragma GCC optimize ("trapv")} kills the program on integer overflows (but is really slow).
 		\end{itemize}
 	\kactlimport{FastMod.h}
+	% \kactlimport{FastInput.h}
 	\kactlimport{BumpAllocator.h}
 	\kactlimport{SmallPtr.h}
 	\kactlimport{BumpAllocatorSTL.h}


### PR DESCRIPTION
I remember we had some discussions about the most ergonomic API, feel free to suggest changes.

Other than that, there's 2 main decisions that we want to consider.

1. Using `fread` instead of `getchar_unlocked`. `fread` is about 2x faster, for a total of 6x faster than cin.
2. Augment this implementation to read in floats as well.

First one seems more worth it. It's fairly easy to read in floats if needed (by reading both parts and doing some manual division). In addition, if you're ever in the situation where you need fast IO you might as well use the fastest IO you can get.