### PR TITLE
Update documentation of ConvexHull.h

### DIFF
--- a/content/geometry/ConvexHull.h
+++ b/content/geometry/ConvexHull.h
@@ -5,7 +5,7 @@
  * Source: https://github.com/stjepang/snippets/blob/master/convex_hull.cpp
  * Description:
 \\\begin{minipage}{75mm}
-Returns a vector of indices of the convex hull in counter-clockwise order.
+Returns a the points of the convex hull in counter-clockwise order.
 Points on the edge of the hull between two other points are not considered part of the hull.
 \end{minipage}
 \begin{minipage}{15mm}

--- a/content/geometry/ConvexHull.h
+++ b/content/geometry/ConvexHull.h
@@ -5,7 +5,7 @@
  * Source: https://github.com/stjepang/snippets/blob/master/convex_hull.cpp
  * Description:
 \\\begin{minipage}{75mm}
-Returns a the points of the convex hull in counter-clockwise order.
+Returns a vector of the points of the convex hull in counter-clockwise order.
 Points on the edge of the hull between two other points are not considered part of the hull.
 \end{minipage}
 \begin{minipage}{15mm}


### PR DESCRIPTION
It says in the pdf that this function returns the *indices* of the convex hull. That's not correct any longer as it returns the actual points (see the return type and line 32).