### PR TITLE
Remove distance from LCA

### DIFF
--- a/content/graph/LCA.h
+++ b/content/graph/LCA.h
@@ -27,10 +27,10 @@ struct LCA {
 		}
 	}
 
-	int query(int a, int b) {
+	int lca(int a, int b) {
 		if (a == b) return a;
 		tie(a, b) = minmax(time[a], time[b]);
 		return path[rmq.query(a, b)];
 	}
-	// dist(a,b) { return dist[a] + dist[b] - 2*dist[lca(a,b)]; }
+	//dist(a,b){return depth[a] + depth[b] - 2*depth[lca(a,b)];}
 };

--- a/content/graph/LCA.h
+++ b/content/graph/LCA.h
@@ -32,4 +32,5 @@ struct LCA {
 		tie(a, b) = minmax(time[a], time[b]);
 		return path[rmq.query(a, b)];
 	}
+	// dist(a,b) { return dist[a] + dist[b] - 2*dist[lca(a,b)]; }
 };

--- a/content/graph/LCA.h
+++ b/content/graph/LCA.h
@@ -3,35 +3,27 @@
  * Date: 2020-02-20
  * License: CC0
  * Source: Folklore
- * Status: Somewhat tested
+ * Status: stress-tested
  * Description: Data structure for computing lowest common ancestors in a tree
  * (with 0 as root). C should be an adjacency list of the tree, either directed
- * or undirected. Can also find the distance between two nodes.
- * Usage:
- *  LCA lca(undirGraph);
- *  lca.query(firstNode, secondNode);
- *  lca.distance(firstNode, secondNode);
+ * or undirected.
  * Time: $O(N \log N + Q)$
  */
 #pragma once
-
-typedef vector<pii> vpi;
-typedef vector<vpi> graph;
 
 #include "../data-structures/RMQ.h"
 
 struct LCA {
 	int T = 0;
 	vi time, path, ret;
-	vector<ll> dist;
 	RMQ<int> rmq;
 
-	LCA(graph& C):time(sz(C)), dist(sz(C)), rmq((dfs(C), ret)) {}
-	void dfs(graph& C, int v = 0, int p = -1, ll di = 0) {
-		time[v] = T++, dist[v] = di;
-		trav(e, C[v]) if (e.first != p) {
+	LCA(vector<vi>& C) : time(sz(C)), rmq((dfs(C,0,-1), ret)) {}
+	void dfs(vector<vi>& C, int v, int par) {
+		time[v] = T++;
+		trav(y, C[v]) if (y != par) {
 			path.push_back(v), ret.push_back(time[v]);
-			dfs(C, e.first, v, di + e.second);
+			dfs(C, y, v);
 		}
 	}
 
@@ -39,9 +31,5 @@ struct LCA {
 		if (a == b) return a;
 		tie(a, b) = minmax(time[a], time[b]);
 		return path[rmq.query(a, b)];
-	}
-	ll distance(int a, int b) {
-		int lca = query(a, b);
-		return dist[a] + dist[b] - 2 * dist[lca];
 	}
 };

--- a/stress-tests/graph/LCA.cpp
+++ b/stress-tests/graph/LCA.cpp
@@ -45,33 +45,36 @@ struct LCA {
 }
 
 
-void getPars(vector<vector<pair<int, int>>> &tree, int cur, int p, int d, vector<int> &par, vector<int> &depth) {
+void getPars(vector<vi> &tree, int cur, int p, int d, vector<int> &par, vector<int> &depth) {
     par[cur] = p;
     depth[cur] = d;
-    for(auto i: tree[cur]) {
-        if (i.first == p) continue;
-        getPars(tree, i.first, cur, d+1, par, depth);
+    for(auto i: tree[cur]) if (i != p) {
+        getPars(tree, i, cur, d+1, par, depth);
     }
 }
 void test_n(int n, int num) {
     for (int out=0; out<num; out++) {
         auto graph = genRandomTree(n);
-        vector<vector<pair<int, int>>> tree(n);
+        vector<vi> tree(n);
+        vector<vector<pair<int, int>>> oldTree(n);
         for (auto i: graph) {
-            tree[i.first].push_back({i.second, 1});
-            tree[i.second].push_back({i.first, 1});
+            tree[i.first].push_back(i.second);
+            tree[i.second].push_back(i.first);
+            oldTree[i.first].push_back({i.second, 1});
+            oldTree[i.second].push_back({i.first, 1});
         }
         vector<int> par(n), depth(n);
         getPars(tree, 0, 0, 0, par, depth);
         vector<vi> tbl = treeJump(par);
         LCA new_lca(tree);
-        old::LCA old_lca(tree);
+        old::LCA old_lca(oldTree);
         for (int i=0; i<100; i++) {
             int a = rand()%n, b = rand()%n;
             int binLca = lca(tbl, depth, a, b);
-            int binDist = depth[a] + depth[b] - 2*depth[binLca];
-            assert(new_lca.distance(a,b) == old_lca.distance(a,b));
-            assert(binDist == new_lca.distance(a, b));
+            int newLca = new_lca.query(a,b);
+            int oldLca = old_lca.query(a,b);
+            assert(oldLca == newLca);
+            assert(binLca == newLca);
         }
     }
 }

--- a/stress-tests/graph/LCA.cpp
+++ b/stress-tests/graph/LCA.cpp
@@ -71,7 +71,7 @@ void test_n(int n, int num) {
         for (int i=0; i<100; i++) {
             int a = rand()%n, b = rand()%n;
             int binLca = lca(tbl, depth, a, b);
-            int newLca = new_lca.query(a,b);
+            int newLca = new_lca.lca(a,b);
             int oldLca = old_lca.query(a,b);
             assert(oldLca == newLca);
             assert(binLca == newLca);

--- a/stress-tests/utilities/genTree.h
+++ b/stress-tests/utilities/genTree.h
@@ -12,7 +12,7 @@ vector<pair<int,int>> pruferCodeToTree(vector<int> &pruferCode) {
     // Set of integers absent in prufer code. They are the leaves
     set<int> leaves;
 
-    int len = pruferCode.size();
+    int len = (int) pruferCode.size();
     int node = len + 2;
 
     // Count frequency of nodes


### PR DESCRIPTION
Fixes #146. Removes 8 lines of code and 4 lines of description, and makes it more obvious how to use the LCA. At the same time, if you do need this, it's easy to re-introduce manually.