### PR TITLE
Let `eulerWalk()` return the edge indices by default

### DIFF
--- a/content/graph/EulerWalk.h
+++ b/content/graph/EulerWalk.h
@@ -6,26 +6,44 @@
  * Description: Eulerian undirected/directed path/cycle algorithm.
  * Input should be a vector of (dest, global edge index), where
  * for undirected graphs, forward/backward edges have the same index.
- * Returns a list of nodes in the Eulerian path/cycle with src at both start and end, or
- * empty list if no cycle/path exists.
- * To get edge indices back, add .second to s and ret.
+ * Returns a list of pairs of the nodes in the Eulerian path/cycle with src at both start and end,
+ * and the edge indices, or empty list if no cycle/path exists.
  * Time: O(V + E)
  * Status: stress-tested
  */
 #pragma once
 
-vi eulerWalk(vector<vector<pii>>& gr, int nedges, int src=0) {
-	int n = sz(gr);
-	vi D(n), its(n), eu(nedges), ret, s = {src};
-	D[src]++; // to allow Euler paths, not just cycles
-	while (!s.empty()) {
-		int x = s.back(), y, e, &it = its[x], end = sz(gr[x]);
-		if (it == end){ ret.push_back(x); s.pop_back(); continue; }
-		tie(y, e) = gr[x][it++];
-		if (!eu[e]) {
-			D[x]--, D[y]++;
-			eu[e] = 1; s.push_back(y);
-		}}
-	for (int x : D) if (x < 0 || sz(ret) != nedges+1) return {};
-	return {ret.rbegin(), ret.rend()};
+vector<pii> eulerWalk(const vector<vector<pii>>& gr, int nedges, int src = -1) {
+  int n = sz(gr);
+  if (src == -1) {
+    // Find a non-isolated node.
+    src = find_if(all(gr), [](const vector<pii>& v) { return !v.empty(); }) -
+          begin(gr);
+    if (src == n) return {};
+  }
+
+  vi D(n), its(n), eu(nedges);
+  vector<pii> s = {make_pair(src, -1)};
+  vector<pii> ret;
+  D[src]++;  // to allow Euler paths, not just cycles
+  while (!s.empty()) {
+    auto x = s.back();
+    int y, e, &it = its[x.first], end = sz(gr[x.first]);
+    if (it == end) {
+      ret.emplace_back(x);
+      s.pop_back();
+      continue;
+    }
+    tie(y, e) = gr[x.first][it++];
+    if (!eu[e]) {
+      D[x.first]--, D[y]++;
+      eu[e] = 1;
+      s.emplace_back(y, e);
+    }
+  }
+  for (int x : D)
+    if (x < 0) return {};
+  if (sz(ret) != nedges + 1) return {};
+  reverse(all(ret));
+  return ret;
 }


### PR DESCRIPTION
I think that you already have thought about this and have your reasons why you didn't do that.
If you'd like to point out the reasons, I'll be grateful, because I thought of possible reasons and couldn't find any.
The only disadvantage is that the code is a bit longer in my opinion.

The changes:
- Let the default behavior be to return the edge indices.
Justification: If you don't want them, you'll just not use them, but if you want them, you'll have to do a change (minor yet still a change).
- Let the default `src` be a non-isolated node.
Justification: If I want to get a cycle and the graph can have isolated nodes, I'll need to specify the node myself.
Bonus: What about searching for an odd-degree node first to account for the case of Euler Path? I think this should be done too.
- Don't create a new vector just to return.
Justification: It's a nitpick, I'm not sure if it's worthy.