### PR TITLE
Make `LineContainer.inf` static

### DIFF
--- a/content/data-structures/LineContainer.h
+++ b/content/data-structures/LineContainer.h
@@ -18,7 +18,7 @@ struct Line {
 
 struct LineContainer : multiset<Line, less<>> {
 	// (for doubles, use inf = 1/.0, div(a,b) = a/b)
-	const ll inf = LLONG_MAX;
+	static const ll inf = LLONG_MAX;
 	ll div(ll a, ll b) { // floored division
 		return a / b - ((a ^ b) < 0 && a % b); }
 	bool isect(iterator x, iterator y) {


### PR DESCRIPTION
This allows us to use the assignment operator `=` with `LineContainer` objects.
Without making it static, trying to do `line_container1 = line_container2;` results in a compilation error.