### PR TITLE
fix wrong cut in global min cut

### DIFF
--- a/content/graph/GlobalMinCut.h
+++ b/content/graph/GlobalMinCut.h
@@ -10,7 +10,9 @@
 
 pair<int, vi> getMinCut(vector<vi>& weights) {
 	int N = sz(weights);
-	vi used(N), cut, best_cut;
+	vi used(N), best_cut;
+	vector<vi> cuts(N);
+	rep(i,0,N) cuts[i] = {i};
 	int best_weight = -1;
 
 	for (int phase = N-1; phase >= 0; phase--) {
@@ -25,9 +27,9 @@ pair<int, vi> getMinCut(vector<vi>& weights) {
 				rep(j,0,N) weights[prev][j] += weights[k][j];
 				rep(j,0,N) weights[j][prev] = weights[prev][j];
 				used[k] = true;
-				cut.push_back(k);
+				copy(all(cuts[k]), back_inserter(cuts[prev]));
 				if (best_weight == -1 || w[k] < best_weight) {
-					best_cut = cut;
+					best_cut = cuts[k];
 					best_weight = w[k];
 				}
 			} else {


### PR DESCRIPTION
Currently the cut returned by `GlobalMinCut.h` doesn't achieve the value of the minimal cut. This is also noted on the [Wikipedia](https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm) page, which uses the same code - upto coding conventions. This PR fixes this problem.