### PR TITLE
Use a freelist for FastDelaunay

### DIFF
--- a/content/geometry/FastDelaunay.h
+++ b/content/geometry/FastDelaunay.h
@@ -22,24 +22,24 @@ typedef __int128_t lll; // (can be ll if coords are < 2e4)
 P arb(LLONG_MAX,LLONG_MAX); // not equal to any other point
 
 struct Quad {
-	bool mark; Q o, rot; P p;
-	P F() { return r()->p; }
-	Q r() { return rot->rot; }
+	bool mark = 0; Q o, rot; P p;
+	P& F() { return r()->p; }
+	Q& r() { return rot->rot; }
 	Q prev() { return rot->o->rot; }
 	Q next() { return r()->prev(); }
-};
+} *head;
 
-bool circ(P p, P a, P b, P c) { // is p in the circumcircle?
+int circ(P p, P a, P b, P c) { // is p in the circumcircle?
 	lll p2 = p.dist2(), A = a.dist2()-p2,
 	    B = b.dist2()-p2, C = c.dist2()-p2;
 	return p.cross(a,b)*C + p.cross(b,c)*A + p.cross(c,a)*B > 0;
 }
 Q makeEdge(P orig, P dest) {
-	Q q[] = {new Quad{0,0,0,orig}, new Quad{0,0,0,arb},
-	         new Quad{0,0,0,dest}, new Quad{0,0,0,arb}};
-	rep(i,0,4)
-		q[i]->o = q[-i & 3], q[i]->rot = q[(i+1) & 3];
-	return *q;
+	Q r = head; head = r->r()->r();
+	r->r()->r() = r;
+	rep(i,0,4) r = r->rot, r->p = arb, r->o = i & 1 ? r : r->r();
+	r->p = orig; r->F() = dest;
+	return r;
 }
 void splice(Q a, Q b) {
 	swap(a->o->rot->o, b->o->rot->o); swap(a->o, b->o);
@@ -78,7 +78,7 @@ pair<Q,Q> rec(const vector<P>& s) {
 			Q t = e->dir; \
 			splice(e, e->prev()); \
 			splice(e->r(), e->r()->prev()); \
-			e = t; \
+			e->r()->r() = head; head = e; e = t; \
 		}
 	for (;;) {
 		DEL(LC, base->r(), o);  DEL(RC, base, prev());
@@ -94,9 +94,11 @@ pair<Q,Q> rec(const vector<P>& s) {
 vector<P> triangulate(vector<P> pts) {
 	sort(all(pts));  assert(unique(all(pts)) == pts.end());
 	if (sz(pts) < 2) return {};
+	int qi = 0, cap = sz(pts) * 16 + 60;
+	head = new Quad[cap];
+	rep(i,0,cap) head[i].rot = head + i + 1;
 	Q e = rec(pts).first;
 	vector<Q> q = {e};
-	int qi = 0;
 	while (e->o->F().cross(e->F(), e->p) < 0) e = e->o;
 #define ADD { Q c = e; do { c->mark = 1; pts.push_back(c->p); \
 	q.push_back(c->r()); c = c->next(); } while (c != e); }

--- a/content/geometry/FastDelaunay.h
+++ b/content/geometry/FastDelaunay.h
@@ -29,7 +29,7 @@ struct Quad {
 	Q next() { return r()->prev(); }
 } *H;
 
-int circ(P p, P a, P b, P c) { // is p in the circumcircle?
+bool circ(P p, P a, P b, P c) { // is p in the circumcircle?
 	lll p2 = p.dist2(), A = a.dist2()-p2,
 	    B = b.dist2()-p2, C = c.dist2()-p2;
 	return p.cross(a,b)*C + p.cross(b,c)*A + p.cross(c,a)*B > 0;

--- a/content/geometry/FastDelaunay.h
+++ b/content/geometry/FastDelaunay.h
@@ -22,9 +22,9 @@ typedef __int128_t lll; // (can be ll if coords are < 2e4)
 P arb(LLONG_MAX,LLONG_MAX); // not equal to any other point
 
 struct Quad {
-	bool mark = 0; Q o, rot; P p;
+	Q rot, o; P p = arb; bool mark;
 	P& F() { return r()->p; }
-	Q r() { return rot->rot; }
+	Q& r() { return rot->rot; }
 	Q prev() { return rot->o->rot; }
 	Q next() { return r()->prev(); }
 } *H;
@@ -35,7 +35,8 @@ int circ(P p, P a, P b, P c) { // is p in the circumcircle?
 	return p.cross(a,b)*C + p.cross(b,c)*A + p.cross(c,a)*B > 0;
 }
 Q makeEdge(P orig, P dest) {
-	Q r = H; H = r->o;
+	Q r = H ? H : new Quad{new Quad{new Quad{new Quad{0}}}};
+	H = r->o; r->r()->r() = r;
 	rep(i,0,4) r = r->rot, r->p = arb, r->o = i & 1 ? r : r->r();
 	r->p = orig; r->F() = dest;
 	return r;
@@ -93,11 +94,9 @@ pair<Q,Q> rec(const vector<P>& s) {
 vector<P> triangulate(vector<P> pts) {
 	sort(all(pts));  assert(unique(all(pts)) == pts.end());
 	if (sz(pts) < 2) return {};
-	int qi = 0, cap = sz(pts) * 16 + 60;
-	H = new Quad[cap + 4] + 4;
-	rep(i,0,cap) H[i - 4].o = H[i ^ ((2*i+3) & 3)].rot = H + i;
 	Q e = rec(pts).first;
 	vector<Q> q = {e};
+	int qi = 0;
 	while (e->o->F().cross(e->F(), e->p) < 0) e = e->o;
 #define ADD { Q c = e; do { c->mark = 1; pts.push_back(c->p); \
 	q.push_back(c->r()); c = c->next(); } while (c != e); }

--- a/content/geometry/FastDelaunay.h
+++ b/content/geometry/FastDelaunay.h
@@ -24,10 +24,10 @@ P arb(LLONG_MAX,LLONG_MAX); // not equal to any other point
 struct Quad {
 	bool mark = 0; Q o, rot; P p;
 	P& F() { return r()->p; }
-	Q& r() { return rot->rot; }
+	Q r() { return rot->rot; }
 	Q prev() { return rot->o->rot; }
 	Q next() { return r()->prev(); }
-} *head;
+} *H;
 
 int circ(P p, P a, P b, P c) { // is p in the circumcircle?
 	lll p2 = p.dist2(), A = a.dist2()-p2,
@@ -35,8 +35,7 @@ int circ(P p, P a, P b, P c) { // is p in the circumcircle?
 	return p.cross(a,b)*C + p.cross(b,c)*A + p.cross(c,a)*B > 0;
 }
 Q makeEdge(P orig, P dest) {
-	Q r = head; head = r->r()->r();
-	r->r()->r() = r;
+	Q r = H; H = r->o;
 	rep(i,0,4) r = r->rot, r->p = arb, r->o = i & 1 ? r : r->r();
 	r->p = orig; r->F() = dest;
 	return r;
@@ -78,7 +77,7 @@ pair<Q,Q> rec(const vector<P>& s) {
 			Q t = e->dir; \
 			splice(e, e->prev()); \
 			splice(e->r(), e->r()->prev()); \
-			e->r()->r() = head; head = e; e = t; \
+			e->o = H; H = e; e = t; \
 		}
 	for (;;) {
 		DEL(LC, base->r(), o);  DEL(RC, base, prev());
@@ -95,8 +94,8 @@ vector<P> triangulate(vector<P> pts) {
 	sort(all(pts));  assert(unique(all(pts)) == pts.end());
 	if (sz(pts) < 2) return {};
 	int qi = 0, cap = sz(pts) * 16 + 60;
-	head = new Quad[cap];
-	rep(i,0,cap) head[i].rot = head + i + 1;
+	H = new Quad[cap + 4] + 4;
+	rep(i,0,cap) H[i - 4].o = H[i ^ ((2*i+3) & 3)].rot = H + i;
 	Q e = rec(pts).first;
 	vector<Q> q = {e};
 	while (e->o->F().cross(e->F(), e->p) < 0) e = e->o;

--- a/stress-tests/geometry/FastDelaunay.cpp
+++ b/stress-tests/geometry/FastDelaunay.cpp
@@ -30,11 +30,13 @@ struct Bumpalloc {
 
 // When not testing perf, we don't want to leak memory
 #ifndef TEST_PERF
-#define new bumpalloc =
+#define bool void* operator new[](size_t size) { return bumpalloc.alloc(size); } bool
+#undef assert
+#define assert(x) do { if (!(x)) { cout << "Assertion failed: " << #x << endl; abort(); } } while (0)
 #endif
 #include "../../content/geometry/FastDelaunay.h"
 #ifndef TEST_PERF
-#undef new
+#undef bool
 #endif
 
 template<class A, class F>

--- a/stress-tests/geometry/FastDelaunay.cpp
+++ b/stress-tests/geometry/FastDelaunay.cpp
@@ -30,7 +30,10 @@ struct Bumpalloc {
 
 // When not testing perf, we don't want to leak memory
 #ifndef TEST_PERF
-#define bool void* operator new[](size_t size) { return bumpalloc.alloc(size); } bool
+#define bool \
+	void* operator new[](size_t size) { return bumpalloc.alloc(size); } \
+	void* operator new(size_t size) { return bumpalloc.alloc(size); } \
+	bool
 #undef assert
 #define assert(x) do { if (!(x)) { cout << "Assertion failed: " << #x << endl; abort(); } } while (0)
 #endif

--- a/stress-tests/geometry/FastDelaunay.cpp
+++ b/stress-tests/geometry/FastDelaunay.cpp
@@ -30,16 +30,11 @@ struct Bumpalloc {
 
 // When not testing perf, we don't want to leak memory
 #ifndef TEST_PERF
-#define bool \
-	void* operator new[](size_t size) { return bumpalloc.alloc(size); } \
-	void* operator new(size_t size) { return bumpalloc.alloc(size); } \
-	bool
-#undef assert
-#define assert(x) do { if (!(x)) { cout << "Assertion failed: " << #x << endl; abort(); } } while (0)
+#define new bumpalloc =
 #endif
 #include "../../content/geometry/FastDelaunay.h"
 #ifndef TEST_PERF
-#undef bool
+#undef new
 #endif
 
 template<class A, class F>


### PR DESCRIPTION
Makes it about 33% faster, and reduces memory usage from O(n log n) to O(n). See discussion in #194. Closes #193.