### PR TITLE
Better compiler flags during `make test-compile`

### DIFF
--- a/doc/scripts/test-compiles.sh
+++ b/doc/scripts/test-compiles.sh
@@ -4,4 +4,5 @@ echo "
 #include \"../content/contest/template.cpp\"
 #include \"../$FILE\"
 " >build/temp.cpp
-g++ -Wall -Wextra -Wfatal-errors -Wconversion -std=c++14 build/temp.cpp && rm a.out build/temp.cpp
+# Catching silly mistakes with GCC: https://codeforces.com/blog/entry/15547
+g++  -Wall -Wextra -pedantic -Wconversion -Wno-unused-result -Wfatal-errors -DLOCAL -std=c++2a  -O2 -Wshadow -Wformat=2 -Wfloat-equal -Wcast-qual -Wcast-align -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fstack-protector build/temp.cpp && rm a.out build/temp.cpp

--- a/doc/scripts/test-compiles.sh
+++ b/doc/scripts/test-compiles.sh
@@ -5,4 +5,4 @@ echo "
 #include \"../$FILE\"
 " >build/temp.cpp
 # Catching silly mistakes with GCC: https://codeforces.com/blog/entry/15547
-g++  -Wall -Wextra -pedantic -Wconversion -Wno-unused-result -Wfatal-errors -DLOCAL -std=c++2a  -O2 -Wshadow -Wformat=2 -Wfloat-equal -Wcast-qual -Wcast-align -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fstack-protector build/temp.cpp && rm a.out build/temp.cpp
+g++  -Wall -Wextra -pedantic -Wconversion -Wno-unused-result -Wfatal-errors -std=c++14  -Wshadow -Wformat=2 -Wfloat-equal -Wcast-qual -Wcast-align build/temp.cpp && rm a.out build/temp.cpp

--- a/doc/scripts/test-compiles.sh
+++ b/doc/scripts/test-compiles.sh
@@ -5,4 +5,4 @@ echo "
 #include \"../$FILE\"
 " >build/temp.cpp
 # Catching silly mistakes with GCC: https://codeforces.com/blog/entry/15547
-g++  -Wall -Wextra -pedantic -Wconversion -Wno-unused-result -Wfatal-errors -std=c++14  -Wshadow -Wformat=2 -Wfloat-equal -Wcast-qual -Wcast-align build/temp.cpp && rm a.out build/temp.cpp
+g++ -Wall -Wextra -O2 -Wfatal-errors -Wconversion -std=c++14 -pedantic -Wno-unused-result -Wshadow -Wformat=2 -Wfloat-equal -Wlogical-op -Wshift-overflow=2 -Wduplicated-cond -Wcast-qual -Wcast-align build/temp.cpp && rm a.out build/temp.cpp


### PR DESCRIPTION
https://codeforces.com/blog/entry/15547: better compiler flags during test compile.

Backstory on how I found this: I stole your build+test scrips to better test my CP repo https://github.com/lrvideckis/Programming-Team-Code/tree/master/scripts (great scripts BTW!). And I found a bunch of compiler warnings (one warning was due to a bug!). 

Also what do you think about using `-std=c++2a`?