### PR TITLE
Improve MCMF

### DIFF
--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -2,11 +2,11 @@
  * Author: Stanford
  * Date: Unknown
  * Source: Stanford Notebook
- * Description: Min-cost max-flow. Double edges are allowed.
+ * Description: Min-cost max-flow.
  *  If costs can be negative, call setpi before maxflow, but note that negative cost cycles are not supported.
  *  To obtain the actual flow, look at positive values only.
  * Status: Tested on kattis:mincostmaxflow, stress-tested against another implementation
- * Time: $O(F \cdot Elog(V))$ if all costs are positive, where F is max flow. Otherwise $O(F \cdot Elog(V)+VE)$
+ * Time: $O(F \cdot E \log(V))$ where F is max flow. $O(VE)$ for setpi.
  */
 #pragma once
 
@@ -15,8 +15,7 @@
 const ll INF = numeric_limits<ll>::max() / 4;
 
 struct MCMF {
-	struct edge
-	{
+	struct edge {
 		int from, to, rev;
 		ll cap, cost, flow;
 	};

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -46,8 +46,7 @@ struct MCMF {
 		while (!q.empty()) {
 			s = q.top().second; q.pop();
 			seen[s] = 1; di = dist[s] + pi[s];
-			for (edge& e : ed[s]) if (!seen[e.to])
-			{
+			for (edge& e : ed[s]) if (!seen[e.to]) {
 				ll val = di - pi[e.to] + e.cost;
 				if (e.cap - e.flow > 0 && val < dist[e.to]) {
 					dist[e.to] = val;

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -29,8 +29,8 @@ struct MCMF {
 
 	void addEdge(int from, int to, ll cap, ll cost) {
 		if (from == to) return;
-		ed[from].emplace_back(edge{ from,to,sz(ed[to]),cap,cost,0});
-		ed[to].emplace_back(edge{ to,from,sz(ed[from])-1,0,-cost,0});
+		ed[from].push_back(edge{ from,to,sz(ed[to]),cap,cost,0 });
+		ed[to].push_back(edge{ to,from,sz(ed[from]) - 1,0,-cost,0 });
 	}
 
 	void path(int s) {
@@ -50,29 +50,32 @@ struct MCMF {
 				if (e.cap - e.flow > 0 && val < dist[e.to]) {
 					dist[e.to] = val;
 					par[e.to] = &e;
-					if (its[e.to] == q.end()) its[e.to] = q.push({ -dist[e.to], e.to });
-					else q.modify(its[e.to], { -dist[e.to], e.to });
+					if (its[e.to] == q.end())
+						its[e.to] = q.push({ -dist[e.to], e.to });
+					else
+						q.modify(its[e.to], { -dist[e.to], e.to });
 				}
 			}
 		}
-		rep(i,0,N) pi[i] = min(pi[i] + dist[i], INF);
+		rep(i, 0, N) pi[i] = min(pi[i] + dist[i], INF);
 	}
 
 	pair<ll, ll> maxflow(int s, int t) {
 		ll totflow = 0, totcost = 0;
 		while (path(s), seen[t]) {
 			ll fl = INF;
-			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p)
-				fl = min(fl, par[x]->cap - par[x]->flow);
+			
+			for (edge* x = par[t]; x; (x = par[x->from]))
+				fl = min(fl, x->cap - x->flow);
 
 			totflow += fl;
-			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p) {
-				par[x]->flow += fl;
-				ed[par[x]->to][par[x]->rev].flow -= fl;
+			for (edge* x = par[t]; x; (x = par[x->from])) {
+				x->flow += fl;
+				ed[x->to][x->rev].flow -= fl;
 			}
 		}
-		rep(i,0,N) for (edge& e : ed[i]) totcost += e.cost * e.flow;
-		return {totflow, totcost/2};
+		rep(i, 0, N) for(edge& e : ed[i]) totcost += e.cost*e.flow;
+		return { totflow, totcost / 2 };
 	}
 
 	// If some costs can be negative, call this before maxflow:
@@ -80,10 +83,10 @@ struct MCMF {
 		fill(all(pi), INF); pi[s] = 0;
 		int it = N, ch = 1; ll v;
 		while (ch-- && it--)
-			rep(i,0,N) if (pi[i] != INF)
-				for (edge& e : ed[i]) if (e.cap)
-					if ((v = pi[i] + e.cost) < pi[e.to])
-						pi[e.to] = v, ch = 1;
+			rep(i, 0, N) if (pi[i] != INF)
+			for (edge& e : ed[i]) if (e.cap)
+				if ((v = pi[i] + e.cost) < pi[e.to])
+					pi[e.to] = v, ch = 1;
 		assert(it >= 0); // negative cost cycle
 	}
 };

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -67,8 +67,7 @@ struct MCMF {
 				fl = min(fl, par[x]->cap - par[x]->flow);
 
 			totflow += fl;
-			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p)
-			{
+			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p) {
 				par[x]->flow += fl;
 				ed[par[x]->to][par[x]->rev].flow -= fl;
 			}

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -6,7 +6,7 @@
  *  If costs can be negative, call setpi before maxflow, but note that negative cost cycles are not supported.
  *  To obtain the actual flow, look at positive values only.
  * Status: Tested on kattis:mincostmaxflow, stress-tested against another implementation
- * Time: $O(F \cdot Elog(N))$ if all costs are positive, where F is max flow. Otherwise $O(F \cdot Elog(N)+VE)$
+ * Time: $O(F \cdot Elog(V))$ if all costs are positive, where F is max flow. Otherwise $O(F \cdot Elog(V)+VE)$
  */
 #pragma once
 
@@ -22,7 +22,7 @@ struct MCMF {
 	};
 	int N;
 	vector<vector<edge>> ed;
-	vi seen, ind;
+	vi seen;
 	vector<ll> dist, pi;
 	vector<edge*> par;
 

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -2,7 +2,7 @@
  * Author: Stanford
  * Date: Unknown
  * Source: Stanford Notebook
- * Description: Min-cost max-flow. cap[i][j] != cap[j][i] is allowed; double edges are not.
+ * Description: Min-cost max-flow. Double edges are allowed.
  *  If costs can be negative, call setpi before maxflow, but note that negative cost cycles are not supported.
  *  To obtain the actual flow, look at positive values only.
  * Status: Tested on kattis:mincostmaxflow, stress-tested against another implementation
@@ -13,7 +13,6 @@
 // #include <bits/extc++.h> /// include-line, keep-include
 
 const ll INF = numeric_limits<ll>::max() / 4;
-typedef vector<ll> VL;
 
 struct MCMF {
 	struct edge
@@ -24,7 +23,7 @@ struct MCMF {
 	int N;
 	vector<vector<edge>> ed;
 	vi seen, ind;
-	vi dist, pi;
+	vector<ll> dist, pi;
 	vector<edge*> par;
 
 	MCMF(int N) :
@@ -38,10 +37,9 @@ struct MCMF {
 
 	void path(int s) {
 		fill(all(seen), 0);
-		fill(all(dist), inf);
+		fill(all(dist), INF);
 		dist[s] = 0; ll di;
 
-		//priority_queue<pair<ll, int>> q;
 		__gnu_pbds::priority_queue<pair<ll, int>> q;
 		vector<decltype(q)::point_iterator> its(N);
 		q.push({ 0, s });
@@ -60,13 +58,13 @@ struct MCMF {
 				}
 			}
 		}
-		rep(i, 0, N) pi[i] = min(pi[i] + dist[i], inf);
+		rep(i, 0, N) pi[i] = min(pi[i] + dist[i], INF);
 	}
 
 	pair<ll, ll> maxflow(int s, int t) {
 		ll totflow = 0, totcost = 0;
 		while (path(s), seen[t]) {
-			ll fl = inf;
+			ll fl = INF;
 			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p)
 				fl = min(fl, par[x]->cap - par[x]->flow);
 
@@ -83,10 +81,10 @@ struct MCMF {
 
 	// If some costs can be negative, call this before maxflow:
 	void setpi(int s) { // (otherwise, leave this out)
-		fill(all(pi), inf); pi[s] = 0;
+		fill(all(pi), INF); pi[s] = 0;
 		int it = N, ch = 1; ll v;
 		while (ch-- && it--)
-			rep(i, 0, N) if (pi[i] != inf)
+			rep(i, 0, N) if (pi[i] != INF)
 				for (edge& e : ed[i]) if (e.cap)
 					if ((v = pi[i] + e.cost) < pi[e.to])
 						pi[e.to] = v, ch = 1;

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -76,7 +76,7 @@ struct MCMF {
 			}
 		}
 		rep(i,0,N) for (edge& e : ed[i]) totcost += e.cost * e.flow;
-		return { totflow, totcost/2 };
+		return {totflow, totcost/2};
 	}
 
 	// If some costs can be negative, call this before maxflow:

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -6,7 +6,7 @@
  *  If costs can be negative, call setpi before maxflow, but note that negative cost cycles are not supported.
  *  To obtain the actual flow, look at positive values only.
  * Status: Tested on kattis:mincostmaxflow, stress-tested against another implementation
- * Time: $O(F \cdot E \log(V))$ where F is max flow. $O(VE)$ for setpi.
+ * Time: $O(F E \log(V))$ where F is max flow. $O(VE)$ for setpi.
  */
 #pragma once
 
@@ -73,7 +73,7 @@ struct MCMF {
 				ed[x->to][x->rev].flow -= fl;
 			}
 		}
-		rep(i,0,N) for(edge& e : ed[i]) totcost += e.cost*e.flow;
+		rep(i,0,N) for(edge& e : ed[i]) totcost += e.cost * e.flow;
 		return {totflow, totcost/2};
 	}
 
@@ -82,7 +82,7 @@ struct MCMF {
 		fill(all(pi), INF); pi[s] = 0;
 		int it = N, ch = 1; ll v;
 		while (ch-- && it--)
-			rep(i, 0, N) if (pi[i] != INF)
+			rep(i,0,N) if (pi[i] != INF)
 			  for (edge& e : ed[i]) if (e.cap)
 				  if ((v = pi[i] + e.cost) < pi[e.to])
 					  pi[e.to] = v, ch = 1;

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -6,7 +6,7 @@
  *  If costs can be negative, call setpi before maxflow, but note that negative cost cycles are not supported.
  *  To obtain the actual flow, look at positive values only.
  * Status: Tested on kattis:mincostmaxflow, stress-tested against another implementation
- * Time: Approximately O(E^2)
+ * Time: $O(F \cdot Elog(N))$ if all costs are positive, where F is max flow. Otherwise $O(F \cdot Elog(N)+VE)$
  */
 #pragma once
 

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -16,78 +16,80 @@ const ll INF = numeric_limits<ll>::max() / 4;
 typedef vector<ll> VL;
 
 struct MCMF {
+	struct edge
+	{
+		int from, to, rev;
+		ll cap, cost, flow;
+	};
 	int N;
-	vector<vi> ed, red;
-	vector<VL> cap, flow, cost;
-	vi seen;
-	VL dist, pi;
-	vector<pii> par;
+	vector<vector<edge>> ed;
+	vi seen, ind;
+	vi dist, pi;
+	vector<edge*> par;
 
 	MCMF(int N) :
-		N(N), ed(N), red(N), cap(N, VL(N)), flow(cap), cost(cap),
-		seen(N), dist(N), pi(N), par(N) {}
+		N(N), ed(N), seen(N), dist(N), pi(N), par(N) {}
 
 	void addEdge(int from, int to, ll cap, ll cost) {
-		this->cap[from][to] = cap;
-		this->cost[from][to] = cost;
-		ed[from].push_back(to);
-		red[to].push_back(from);
+		if (from == to) return;
+		ed[from].emplace_back(edge{ from,to,sz(ed[to]),cap,cost,0});
+		ed[to].emplace_back(edge{ to,from,sz(ed[from])-1,0,-cost,0});
 	}
 
 	void path(int s) {
 		fill(all(seen), 0);
-		fill(all(dist), INF);
+		fill(all(dist), inf);
 		dist[s] = 0; ll di;
 
+		//priority_queue<pair<ll, int>> q;
 		__gnu_pbds::priority_queue<pair<ll, int>> q;
 		vector<decltype(q)::point_iterator> its(N);
-		q.push({0, s});
-
-		auto relax = [&](int i, ll cap, ll cost, int dir) {
-			ll val = di - pi[i] + cost;
-			if (cap && val < dist[i]) {
-				dist[i] = val;
-				par[i] = {s, dir};
-				if (its[i] == q.end()) its[i] = q.push({-dist[i], i});
-				else q.modify(its[i], {-dist[i], i});
-			}
-		};
+		q.push({ 0, s });
 
 		while (!q.empty()) {
 			s = q.top().second; q.pop();
 			seen[s] = 1; di = dist[s] + pi[s];
-			for (int i : ed[s]) if (!seen[i])
-				relax(i, cap[s][i] - flow[s][i], cost[s][i], 1);
-			for (int i : red[s]) if (!seen[i])
-				relax(i, flow[i][s], -cost[i][s], 0);
+			for (edge& e : ed[s]) if (!seen[e.to])
+			{
+				ll val = di - pi[e.to] + e.cost;
+				if (e.cap - e.flow > 0 && val < dist[e.to]) {
+					dist[e.to] = val;
+					par[e.to] = &e;
+					if (its[e.to] == q.end()) its[e.to] = q.push({ -dist[e.to], e.to });
+					else q.modify(its[e.to], { -dist[e.to], e.to });
+				}
+			}
 		}
-		rep(i,0,N) pi[i] = min(pi[i] + dist[i], INF);
+		rep(i, 0, N) pi[i] = min(pi[i] + dist[i], inf);
 	}
 
 	pair<ll, ll> maxflow(int s, int t) {
 		ll totflow = 0, totcost = 0;
 		while (path(s), seen[t]) {
-			ll fl = INF;
-			for (int p,r,x = t; tie(p,r) = par[x], x != s; x = p)
-				fl = min(fl, r ? cap[p][x] - flow[p][x] : flow[x][p]);
+			ll fl = inf;
+			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p)
+				fl = min(fl, par[x]->cap - par[x]->flow);
+
 			totflow += fl;
-			for (int p,r,x = t; tie(p,r) = par[x], x != s; x = p)
-				if (r) flow[p][x] += fl;
-				else flow[x][p] -= fl;
+			for (int p, x = t; par[x] && (p = par[x]->from, x != s); x = p)
+			{
+				par[x]->flow += fl;
+				ed[par[x]->to][par[x]->rev].flow -= fl;
+			}
 		}
-		rep(i,0,N) rep(j,0,N) totcost += cost[i][j] * flow[i][j];
-		return {totflow, totcost};
+		rep(i, 0, N) for (edge& e : ed[i]) totcost += e.cost * e.flow;
+		return { totflow, totcost/2 };
 	}
 
 	// If some costs can be negative, call this before maxflow:
 	void setpi(int s) { // (otherwise, leave this out)
-		fill(all(pi), INF); pi[s] = 0;
+		fill(all(pi), inf); pi[s] = 0;
 		int it = N, ch = 1; ll v;
 		while (ch-- && it--)
-			rep(i,0,N) if (pi[i] != INF)
-				for (int to : ed[i]) if (cap[i][to])
-					if ((v = pi[i] + cost[i][to]) < pi[to])
-						pi[to] = v, ch = 1;
+			rep(i, 0, N) if (pi[i] != inf)
+				for (edge& e : ed[i]) if (e.cap)
+					if ((v = pi[i] + e.cost) < pi[e.to])
+						pi[e.to] = v, ch = 1;
 		assert(it >= 0); // negative cost cycle
 	}
 };

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -26,8 +26,7 @@ struct MCMF {
 	vector<ll> dist, pi;
 	vector<edge*> par;
 
-	MCMF(int N) :
-		N(N), ed(N), seen(N), dist(N), pi(N), par(N) {}
+	MCMF(int N) : N(N), ed(N), seen(N), dist(N), pi(N), par(N) {}
 
 	void addEdge(int from, int to, ll cap, ll cost) {
 		if (from == to) return;

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -58,7 +58,7 @@ struct MCMF {
 				}
 			}
 		}
-		rep(i, 0, N) pi[i] = min(pi[i] + dist[i], INF);
+		rep(i,0,N) pi[i] = min(pi[i] + dist[i], INF);
 	}
 
 	pair<ll, ll> maxflow(int s, int t) {
@@ -75,7 +75,7 @@ struct MCMF {
 				ed[par[x]->to][par[x]->rev].flow -= fl;
 			}
 		}
-		rep(i, 0, N) for (edge& e : ed[i]) totcost += e.cost * e.flow;
+		rep(i,0,N) for (edge& e : ed[i]) totcost += e.cost * e.flow;
 		return { totflow, totcost/2 };
 	}
 
@@ -84,7 +84,7 @@ struct MCMF {
 		fill(all(pi), INF); pi[s] = 0;
 		int it = N, ch = 1; ll v;
 		while (ch-- && it--)
-			rep(i, 0, N) if (pi[i] != INF)
+			rep(i,0,N) if (pi[i] != INF)
 				for (edge& e : ed[i]) if (e.cap)
 					if ((v = pi[i] + e.cost) < pi[e.to])
 						pi[e.to] = v, ch = 1;

--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -30,7 +30,7 @@ struct MCMF {
 	void addEdge(int from, int to, ll cap, ll cost) {
 		if (from == to) return;
 		ed[from].push_back(edge{ from,to,sz(ed[to]),cap,cost,0 });
-		ed[to].push_back(edge{ to,from,sz(ed[from]) - 1,0,-cost,0 });
+		ed[to].push_back(edge{ to,from,sz(ed[from])-1,0,-cost,0 });
 	}
 
 	void path(int s) {
@@ -57,25 +57,24 @@ struct MCMF {
 				}
 			}
 		}
-		rep(i, 0, N) pi[i] = min(pi[i] + dist[i], INF);
+		rep(i,0,N) pi[i] = min(pi[i] + dist[i], INF);
 	}
 
 	pair<ll, ll> maxflow(int s, int t) {
 		ll totflow = 0, totcost = 0;
 		while (path(s), seen[t]) {
 			ll fl = INF;
-			
-			for (edge* x = par[t]; x; (x = par[x->from]))
+			for (edge* x = par[t]; x; x = par[x->from])
 				fl = min(fl, x->cap - x->flow);
 
 			totflow += fl;
-			for (edge* x = par[t]; x; (x = par[x->from])) {
+			for (edge* x = par[t]; x; x = par[x->from]) {
 				x->flow += fl;
 				ed[x->to][x->rev].flow -= fl;
 			}
 		}
-		rep(i, 0, N) for(edge& e : ed[i]) totcost += e.cost*e.flow;
-		return { totflow, totcost / 2 };
+		rep(i,0,N) for(edge& e : ed[i]) totcost += e.cost*e.flow;
+		return {totflow, totcost/2};
 	}
 
 	// If some costs can be negative, call this before maxflow:
@@ -84,9 +83,9 @@ struct MCMF {
 		int it = N, ch = 1; ll v;
 		while (ch-- && it--)
 			rep(i, 0, N) if (pi[i] != INF)
-			for (edge& e : ed[i]) if (e.cap)
-				if ((v = pi[i] + e.cost) < pi[e.to])
-					pi[e.to] = v, ch = 1;
+			  for (edge& e : ed[i]) if (e.cap)
+				  if ((v = pi[i] + e.cost) < pi[e.to])
+					  pi[e.to] = v, ch = 1;
 		assert(it >= 0); // negative cost cycle
 	}
 };


### PR DESCRIPTION
This PR improves 3 things:

1. Fixes the time complexity description, as mentioned in #217 
2. No longer uses quadratic memory (adjacency list instead of matrix). Quadratic memory was problematic on problems with sparse graphs such as [tourist](https://open.kattis.com/problems/tourist).
3. Allows parallell/double edges.

Empirically, it also seems to improve performance (see "improved MCMF" [here](https://docs.google.com/spreadsheets/d/11ucYantzFPazqAlAa3J3-wC3NPmcXl3OMAqFhnXPMr8/edit?usp=sharing))

Potential downsides of new implementation: 
1. Loops (edges from a node to itself) don't work (when would you ever want that, though?)
2. Uses pointers to easily reconstruct path, making some parts less readable.

It passes all stress tests and doesn't get any WA's on the kattis problems I've tried. It might be worth to consider using SPFA for setpi if it does not complicate the code too much.

Side note: does anyone know why we can skip using setpi if input costs are positive? 