### PR TITLE
Add line breaks in some long lines of latex (in descriptions)

### DIFF
--- a/content/data-structures/SegmentTree.h
+++ b/content/data-structures/SegmentTree.h
@@ -3,7 +3,8 @@
  * Date: 2017-10-31
  * License: CC0
  * Source: folklore
- * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right. Can be changed by modifying T, f and unit.
+ * Description: Zero-indexed max-tree. Bounds are inclusive to the left and exclusive to the right.
+ * Can be changed by modifying T, f and unit.
  * Time: O(\log N)
  * Status: stress-tested
  */

--- a/content/geometry/CircleIntersection.h
+++ b/content/geometry/CircleIntersection.h
@@ -2,7 +2,8 @@
  * Author: Simon Lindholm
  * Date: 2015-09-01
  * License: CC0
- * Description: Computes the pair of points at which two circles intersect. Returns false in case of no intersection.
+ * Description: Computes the pair of points at which two circles intersect.
+ * Returns false in case of no intersection.
  * Status: stress-tested
  */
 #pragma once

--- a/content/geometry/SegmentIntersection.h
+++ b/content/geometry/SegmentIntersection.h
@@ -6,7 +6,8 @@
  * Description:\\
 \begin{minipage}{75mm}
 If a unique intersection point between the line segments going from s1 to e1 and from s2 to e2 exists then it is returned.
-If no intersection point exists an empty vector is returned. If infinitely many exist a vector with 2 elements is returned, containing the endpoints of the common line segment.
+If no intersection point exists an empty vector is returned.
+If infinitely many exist a vector with 2 elements is returned, containing the endpoints of the common line segment.
 The wrong position will be returned if P is Point<ll> and the intersection point does not have integer coordinates.
 Products of three coordinates are used in intermediate steps so watch out for overflow if using int or long long.
 \end{minipage}

--- a/content/geometry/lineDistance.h
+++ b/content/geometry/lineDistance.h
@@ -5,7 +5,11 @@
  * Source: Basic math
  * Description:\\
 \begin{minipage}{75mm}
-Returns the signed distance between point p and the line containing points a and b. Positive value on left side and negative on right as seen from a towards b. a==b gives nan. P is supposed to be Point<T> or Point3D<T> where T is e.g. double or long long. It uses products in intermediate steps so watch out for overflow if using int or long long. Using Point3D will always give a non-negative distance. For Point3D, call .dist on the result of the cross product.
+Returns the signed distance between point p and the line containing points a and b.
+Positive value on left side and negative on right as seen from a towards b. a==b gives nan.
+P is supposed to be Point<T> or Point3D<T> where T is e.g. double or long long.
+It uses products in intermediate steps so watch out for overflow if using int or long long.
+Using Point3D will always give a non-negative distance. For Point3D, call .dist on the result of the cross product.
 \end{minipage}
 \begin{minipage}{15mm}
 \includegraphics[width=\textwidth]{content/geometry/lineDistance}

--- a/content/geometry/sideOf.h
+++ b/content/geometry/sideOf.h
@@ -3,7 +3,10 @@
  * Date: 2009-03-21
  * License: CC0
  * Source:
- * Description: Returns where $p$ is as seen from $s$ towards $e$. 1/0/-1 $\Leftrightarrow$ left/on line/right. If the optional argument $eps$ is given 0 is returned if $p$ is within distance $eps$ from the line. P is supposed to be Point<T> where T is e.g. double or long long. It uses products in intermediate steps so watch out for overflow if using int or long long.
+ * Description: Returns where $p$ is as seen from $s$ towards $e$. 1/0/-1 $\Leftrightarrow$ left/on line/right.
+ * If the optional argument $eps$ is given 0 is returned if $p$ is within distance $eps$ from the line.
+ * P is supposed to be Point<T> where T is e.g. double or long long.
+ * It uses products in intermediate steps so watch out for overflow if using int or long long.
  * Usage:
  * 	bool left = sideOf(p1,p2,q)==1;
  * Status: tested

--- a/content/geometry/sphericalDistance.h
+++ b/content/geometry/sphericalDistance.h
@@ -3,7 +3,12 @@
  * Date: 2009-04-07
  * License: CC0
  * Source: My geometric reasoning
- * Description: Returns the shortest distance on the sphere with radius radius between the points with azimuthal angles (longitude) f1 ($\phi_1$) and f2 ($\phi_2$) from x axis and zenith angles (latitude) t1 ($\theta_1$) and t2 ($\theta_2$) from z axis (0 = north pole). All angles measured in radians. The algorithm starts by converting the spherical coordinates to cartesian coordinates so if that is what you have you can use only the two last rows. dx*radius is then the difference between the two points in the x direction and d*radius is the total distance between the points.
+ * Description: Returns the shortest distance on the sphere with radius radius between the points
+ * with azimuthal angles (longitude) f1 ($\phi_1$) and f2 ($\phi_2$) from x axis and zenith angles
+ * (latitude) t1 ($\theta_1$) and t2 ($\theta_2$) from z axis (0 = north pole). All angles measured
+ * in radians. The algorithm starts by converting the spherical coordinates to cartesian coordinates
+ * so if that is what you have you can use only the two last rows. dx*radius is then the difference
+ * between the two points in the x direction and d*radius is the total distance between the points.
  * Status: tested on kattis:airlinehub
  */
 #pragma once

--- a/content/graph/2sat.h
+++ b/content/graph/2sat.h
@@ -3,7 +3,8 @@
  * Date: 2011-11-29
  * License: CC0
  * Source: folklore
- * Description: Calculates a valid assignment to boolean variables a, b, c,... to a 2-SAT problem, so that an expression of the type $(a\|\|b)\&\&(!a\|\|c)\&\&(d\|\|!b)\&\&...$ becomes true, or reports that it is unsatisfiable.
+ * Description: Calculates a valid assignment to boolean variables a, b, c,... to a 2-SAT problem,
+ * so that an expression of the type $(a\|\|b)\&\&(!a\|\|c)\&\&(d\|\|!b)\&\&...$ becomes true, or reports that it is unsatisfiable.
  * Negated variables are represented by bit-inversions (\texttt{\tilde{}x}).
  * Usage:
  *  TwoSat ts(number of boolean variables);

--- a/content/graph/FloydWarshall.h
+++ b/content/graph/FloydWarshall.h
@@ -5,7 +5,8 @@
  * Source: http://en.wikipedia.org/wiki/Floyd–Warshall_algorithm
  * Description: Calculates all-pairs shortest path in a directed graph that might have negative edge weights.
  * Input is an distance matrix $m$, where $m[i][j] = \texttt{inf}$ if $i$ and $j$ are not adjacent.
- * As output, $m[i][j]$ is set to the shortest distance between $i$ and $j$, \texttt{inf} if no path, or \texttt{-inf} if the path goes through a negative-weight cycle.
+ * As output, $m[i][j]$ is set to the shortest distance between $i$ and $j$, \texttt{inf} if no path,
+ * or \texttt{-inf} if the path goes through a negative-weight cycle.
  * Time: O(N^3)
  * Status: slightly tested
  */

--- a/content/graph/MinCut.h
+++ b/content/graph/MinCut.h
@@ -2,6 +2,7 @@
  * Author: Simon Lindholm
  * Date: 2015-05-13
  * Source: Wikipedia
- * Description: After running max-flow, the left side of a min-cut from $s$ to $t$ is given by all vertices reachable from $s$, only traversing edges with positive residual capacity.
+ * Description: After running max-flow, the left side of a min-cut from $s$ to $t$ is given
+ * by all vertices reachable from $s$, only traversing edges with positive residual capacity.
  * Status: works
  */

--- a/content/numerical/GoldenSectionSearch.h
+++ b/content/numerical/GoldenSectionSearch.h
@@ -3,7 +3,10 @@
  * Date: 2009-04-17
  * License: CC0
  * Source: Numeriska algoritmer med matlab, Gerd Eriksson, NADA, KTH
- * Description: Finds the argument minimizing the function $f$ in the interval $[a,b]$ assuming $f$ is unimodal on the interval, i.e. has only one local minimum. The maximum error in the result is $eps$. Works equally well for maximization with a small change in the code. See TernarySearch.h in the Various chapter for a discrete version.
+ * Description: Finds the argument minimizing the function $f$ in the interval $[a,b]$
+ * assuming $f$ is unimodal on the interval, i.e. has only one local minimum. The maximum
+ * error in the result is $eps$. Works equally well for maximization with a small change
+ * in the code. See TernarySearch.h in the Various chapter for a discrete version.
  * Usage:
 	double func(double x) { return 4+x+.3*x*x; }
 	double xmin = gss(-1000,1000,func);

--- a/content/strings/KMP.h
+++ b/content/strings/KMP.h
@@ -2,7 +2,8 @@
  * Author: Johan Sannemo
  * Date: 2016-12-15
  * License: CC0
- * Description: pi[x] computes the length of the longest prefix of s that ends at x, other than s[0...x] itself (abacaba -> 0010123).
+ * Description: pi[x] computes the length of the longest prefix of s that ends at x,
+ * other than s[0...x] itself (abacaba -> 0010123).
  * Can be used to find all occurrences of a string.
  * Time: O(n)
  * Status: Tested on kattis:stringmatching

--- a/content/strings/Zfunc.h
+++ b/content/strings/Zfunc.h
@@ -1,7 +1,8 @@
 /**
  * Author: chilli
  * License: CC0
- * Description: z[x] computes the length of the longest common prefix of s[i:] and s, except z[0] = 0. (abacaba -> 0010301)
+ * Description: z[x] computes the length of the longest common prefix of s[i:] and s,
+ * except z[0] = 0. (abacaba -> 0010301)
  * Time: O(n)
  * Status: stress-tested
  */

--- a/content/various/DivideAndConquerDP.h
+++ b/content/various/DivideAndConquerDP.h
@@ -2,7 +2,8 @@
  * Author: Simon Lindholm
  * License: CC0
  * Source: Codeforces
- * Description: Given $a[i] = \min_{lo(i) \le k < hi(i)}(f(i, k))$ where the (minimal) optimal $k$ increases with $i$, computes $a[i]$ for $i = L..R-1$.
+ * Description: Given $a[i] = \min_{lo(i) \le k < hi(i)}(f(i, k))$ where the (minimal)
+ * optimal $k$ increases with $i$, computes $a[i]$ for $i = L..R-1$.
  * Time: O((N + (hi-lo)) \log N)
  * Status: tested on http://codeforces.com/contest/321/problem/E
  */


### PR DESCRIPTION
In the descriptions of some of the codes the where very long lines. In this pull request y splitted them in to several lines so that the sorce code is more readable.
Note that this does not affect the latex output.