### PR TITLE
Add clarification on gss description

### DIFF
--- a/content/numerical/GoldenSectionSearch.h
+++ b/content/numerical/GoldenSectionSearch.h
@@ -4,9 +4,10 @@
  * License: CC0
  * Source: Numeriska algoritmer med matlab, Gerd Eriksson, NADA, KTH
  * Description: Finds the argument minimizing the function $f$ in the interval $[a,b]$
- * assuming $f$ is unimodal on the interval, i.e. has only one local minimum. The maximum
- * error in the result is $eps$. Works equally well for maximization with a small change
- * in the code. See TernarySearch.h in the Various chapter for a discrete version.
+ * assuming $f$ is unimodal on the interval, i.e. has only one local minimum and no local
+ * maximum. The maximum error in the result is $eps$. Works equally well for maximization
+ * with a small change in the code. See TernarySearch.h in the Various chapter for a
+ * discrete version.
  * Usage:
 	double func(double x) { return 4+x+.3*x*x; }
 	double xmin = gss(-1000,1000,func);


### PR DESCRIPTION
Add the text "and no local maximum" in the description of golden section search (gss) to note that gss may not work well if the function has a local maximum in the interval