### PR TITLE
Use `|` instead of `\|` in 2sat description

### DIFF
--- a/content/graph/2sat.h
+++ b/content/graph/2sat.h
@@ -4,7 +4,8 @@
  * License: CC0
  * Source: folklore
  * Description: Calculates a valid assignment to boolean variables a, b, c,... to a 2-SAT problem,
- * so that an expression of the type $(a\|\|b)\&\&(!a\|\|c)\&\&(d\|\|!b)\&\&...$ becomes true, or reports that it is unsatisfiable.
+ * so that an expression of the type $(a||b)\&\&(!a||c)\&\&(d||!b)\&\&...$
+ * becomes true, or reports that it is unsatisfiable.
  * Negated variables are represented by bit-inversions (\texttt{\tilde{}x}).
  * Usage:
  *  TwoSat ts(number of boolean variables);


### PR DESCRIPTION
Visual difference in the PDF:
Before:
![image](https://github.com/kth-competitive-programming/kactl/assets/85908989/e5f85209-3d54-4de8-8323-ff8ac16421b2)
After: 
![image](https://github.com/kth-competitive-programming/kactl/assets/85908989/d56b74a0-0551-4733-b51e-4f433691f8a2)

With this the or looks more like the or in C++

Also is possible to add spaces like this:
![image](https://github.com/kth-competitive-programming/kactl/assets/85908989/259ece0f-2bdd-4f98-8526-8e2a064fa5a9)
With the latex like this: `$(a\ ||\ b)\ \&\&\ (!a\ ||\ c)\ \&\&\ (d\ ||\ !b)\ \&\&\ ...$`