### PR TITLE
remove depth array from HLD

### DIFF
--- a/content/graph/HLD.h
+++ b/content/graph/HLD.h
@@ -20,15 +20,15 @@
 template <bool VALS_EDGES> struct HLD {
 	int N, tim = 0;
 	vector<vi> adj;
-	vi par, siz, depth, rt, pos;
+	vi par, siz, rt, pos;
 	Node *tree;
 	HLD(vector<vi> adj_)
-		: N(sz(adj_)), adj(adj_), par(N, -1), siz(N, 1), depth(N),
+		: N(sz(adj_)), adj(adj_), par(N, -1), siz(N, 1),
 		  rt(N),pos(N),tree(new Node(0, N)){ dfsSz(0); dfsHld(0); }
 	void dfsSz(int v) {
 		if (par[v] != -1) adj[v].erase(find(all(adj[v]), par[v]));
 		for (int& u : adj[v]) {
-			par[u] = v, depth[u] = depth[v] + 1;
+			par[u] = v;
 			dfsSz(u);
 			siz[v] += siz[u];
 			if (siz[u] > siz[adj[v][0]]) swap(u, adj[v][0]);
@@ -43,10 +43,10 @@ template <bool VALS_EDGES> struct HLD {
 	}
 	template <class B> void process(int u, int v, B op) {
 		for (; rt[u] != rt[v]; v = par[rt[v]]) {
-			if (depth[rt[u]] > depth[rt[v]]) swap(u, v);
+			if (pos[rt[u]] > pos[rt[v]]) swap(u, v);
 			op(pos[rt[v]], pos[v] + 1);
 		}
-		if (depth[u] > depth[v]) swap(u, v);
+		if (pos[u] > pos[v]) swap(u, v);
 		op(pos[u] + VALS_EDGES, pos[v] + 1);
 	}
 	void modifyPath(int u, int v, int val) {


### PR DESCRIPTION
now, HLD is less code && uses less memory

this change uses the observation that if `u` and `v` are on the same vertical path, then comparing depths is the same as comparing preorder values

I did run this test locally, and it passed https://github.com/kth-competitive-programming/kactl/blob/main/stress-tests/graph/HLD.cpp