### PR TITLE
Fix a bug of MinCostMaxFlow.h

### DIFF
--- a/content/graph/MinCostMaxFlow.h
+++ b/content/graph/MinCostMaxFlow.h
@@ -34,6 +34,7 @@ struct MCMF {
 	}
 
 	void path(int s) {
+		fill(all(par), 0);
 		fill(all(seen), 0);
 		fill(all(dist), INF);
 		dist[s] = 0; ll di;


### PR DESCRIPTION
Fix a bug that occur when maxflow function is called multiple times from different source vertices.