### PR TITLE
Fix undefined behavior in Suffix Array

### DIFF
--- a/content/strings/SuffixArray.h
+++ b/content/strings/SuffixArray.h
@@ -21,8 +21,8 @@ struct SuffixArray {
 	vi sa, lcp;
 	SuffixArray(string& s, int lim=256) { // or basic_string<int>
 		int n = sz(s) + 1, k = 0, a, b;
-		vi x(all(s)+1), y(n), ws(max(n, lim)), rank(n);
-		sa = lcp = y, iota(all(sa), 0);
+		vi x(all(s)), y(n), ws(max(n, lim)), rank(n);
+		x.push_back(0), sa = lcp = y, iota(all(sa), 0);
 		for (int j = 0, p = 0; p < n; j = max(1, j * 2), lim = p) {
 			p = j, iota(all(y), n - j);
 			rep(i,0,n) if (sa[i] >= j) y[p++] = sa[i] - j;


### PR DESCRIPTION
Fixes undefined behavior in the Suffix Array implementation caused by copying a value from the end iterator of the string. I was able to get a runtime error on a problem and then get accepted by making this change to the suffix array implementation only.