### PR TITLE
Fix unintended escape character

### DIFF
--- a/content/tex/preprocessor.py
+++ b/content/tex/preprocessor.py
@@ -190,7 +190,7 @@ def processraw(caption, instream, outstream, listingslang = 'raw'):
         print(source, file=outstream)
         print(r"\end{lstlisting}", file=outstream)
     except:
-        print("\kactlerror{Could not read source.}", file=outstream)
+        print(r"\kactlerror{Could not read source.}", file=outstream)
 
 def parse_include(line):
     line = line.strip()


### PR DESCRIPTION
When I tried to build my university kactl version the involved line of code somehow got executed and raised an error. It seems to me it should be a raw string instead of a normal string with escape character "\k".