### PR TITLE
Simplifying treap insert

### DIFF
--- a/content/data-structures/Treap.h
+++ b/content/data-structures/Treap.h
@@ -54,8 +54,8 @@ Node* merge(Node* l, Node* r) {
 }
 
 Node* ins(Node* t, Node* n, int pos) {
-	auto pa = split(t, pos);
-	return merge(merge(pa.first, n), pa.second);
+	auto [l,r] = split(t, pos);
+	return merge(merge(l, n), r);
 }
 
 // Example application: move the range [l, r) to index k


### PR DESCRIPTION
Using auto instead of pair in order to write less.