### PR TITLE
Fix some issues that may cause catastrophic floating point error

### DIFF
--- a/content/geometry/CirclePolygonIntersection.h
+++ b/content/geometry/CirclePolygonIntersection.h
@@ -23,7 +23,7 @@ double circlePoly(P c, double r, vector<P> ps) {
 		if (det <= 0) return arg(p, q) * r2;
 		auto s = max(0., -a-sqrt(det)), t = min(1., -a+sqrt(det));
 		if (t < 0 || 1 <= s) return arg(p, q) * r2;
-		P u = p + d * s, v = p + d * t;
+		P u = p + d * s, v = q + d * (t-1);
 		return arg(p,u) * r2 + u.cross(v)/2 + arg(v,q) * r2;
 	};
 	auto sum = 0.0;

--- a/content/geometry/PolygonCut.h
+++ b/content/geometry/PolygonCut.h
@@ -27,10 +27,10 @@ vector<P> polygonCut(const vector<P>& poly, P s, P e) {
 	vector<P> res;
 	rep(i,0,sz(poly)) {
 		P cur = poly[i], prev = i ? poly[i-1] : poly.back();
-		bool side = s.cross(e, cur) < 0;
-		if (side != (s.cross(e, prev) < 0))
-			res.push_back(lineInter(s, e, cur, prev).second);
-		if (side)
+		auto a = s.cross(e, cur), b = s.cross(e, prev);
+		if ((a < 0) != (b < 0))
+			res.push_back(cur + (prev - cur) * (a / (a - b)));
+		if (a < 0)
 			res.push_back(cur);
 	}
 	return res;


### PR DESCRIPTION

Made the following changes

* change `p+d*t` to `q+d*(t-1)`. The problem is if `-a+sqrt(det) ≫ 1`, then the term `arg(v, q)` is supposed to be identically zero, however if `q ≈ (0, 0)` then it's possible that `p+d ≉ q` and `arg(v, q) ≉ 0`, which results in a large error. See `a.cpp` in the attached file below.
* even if `side != (s.cross(e, prev) < 0)` is true, it is possible that the 4 points are almost collinear that `lineInter` returns the second value being `(0, 0)`. With this change, whenever `(a < 0) != (b < 0)` then `0 ≤ a / (a - b) ≤ 1`, which means the point being pushed is always on the line between `prev` and `cur` i.e. no catastrophic error can happen. See `b.cpp` in the attached file below.

Attachment (demonstration of catastrophic failure): [a.zip](https://github.com/user-attachments/files/18520565/a.zip)
