### PR TITLE
Pass points by value

### DIFF
--- a/content/geometry/Point3D.h
+++ b/content/geometry/Point3D.h
@@ -12,19 +12,18 @@
 
 template<class T> struct Point3D {
 	typedef Point3D P;
-	typedef const P& R;
 	T x, y, z;
 	explicit Point3D(T x=0, T y=0, T z=0) : x(x), y(y), z(z) {}
-	bool operator<(R p) const {
+	bool operator<(P p) const {
 		return tie(x, y, z) < tie(p.x, p.y, p.z); }
-	bool operator==(R p) const {
+	bool operator==(P p) const {
 		return tie(x, y, z) == tie(p.x, p.y, p.z); }
-	P operator+(R p) const { return P(x+p.x, y+p.y, z+p.z); }
-	P operator-(R p) const { return P(x-p.x, y-p.y, z-p.z); }
+	P operator+(P p) const { return P(x+p.x, y+p.y, z+p.z); }
+	P operator-(P p) const { return P(x-p.x, y-p.y, z-p.z); }
 	P operator*(T d) const { return P(x*d, y*d, z*d); }
 	P operator/(T d) const { return P(x/d, y/d, z/d); }
-	T dot(R p) const { return x*p.x + y*p.y + z*p.z; }
-	P cross(R p) const {
+	T dot(P p) const { return x*p.x + y*p.y + z*p.z; }
+	P cross(P p) const {
 		return P(y*p.z - z*p.y, z*p.x - x*p.z, x*p.y - y*p.x);
 	}
 	T dist2() const { return x*x + y*y + z*z; }

--- a/content/geometry/SegmentDistance.h
+++ b/content/geometry/SegmentDistance.h
@@ -21,7 +21,7 @@ Returns the shortest distance between point p and the line segment from point s 
 #include "Point.h"
 
 typedef Point<double> P;
-double segDist(P& s, P& e, P& p) {
+double segDist(P s, P e, P p) {
 	if (s==e) return (p-s).dist();
 	auto d = (e-s).dist2(), t = min(d,max(.0,(p-s).dot(e-s)));
 	return ((p-s)*d-(e-s)*t).dist()/d;

--- a/content/geometry/circumcircle.h
+++ b/content/geometry/circumcircle.h
@@ -18,11 +18,11 @@ The circumcirle of a triangle is the circle intersecting all three vertices. ccR
 #include "Point.h"
 
 typedef Point<double> P;
-double ccRadius(const P& A, const P& B, const P& C) {
+double ccRadius(P A, P B, P C) {
 	return (B-A).dist()*(C-B).dist()*(A-C).dist()/
 			abs((B-A).cross(C-A))/2;
 }
-P ccCenter(const P& A, const P& B, const P& C) {
+P ccCenter(P A, P B, P C) {
 	P b = C-A, c = B-A;
 	return A + (b*c.dist2()-c*b.dist2()).perp()/b.cross(c)/2;
 }

--- a/content/geometry/kdTree.h
+++ b/content/geometry/kdTree.h
@@ -13,15 +13,15 @@ typedef long long T;
 typedef Point<T> P;
 const T INF = numeric_limits<T>::max();
 
-bool on_x(const P& a, const P& b) { return a.x < b.x; }
-bool on_y(const P& a, const P& b) { return a.y < b.y; }
+bool on_x(P a, P b) { return a.x < b.x; }
+bool on_y(P a, P b) { return a.y < b.y; }
 
 struct Node {
 	P pt; // if this is a leaf, the single point in it
 	T x0 = INF, x1 = -INF, y0 = INF, y1 = -INF; // bounds
 	Node *first = 0, *second = 0;
 
-	T distance(const P& p) { // min squared distance to a point
+	T distance(P p) { // min squared distance to a point
 		T x = (p.x < x0 ? x0 : p.x > x1 ? x1 : p.x);
 		T y = (p.y < y0 ? y0 : p.y > y1 ? y1 : p.y);
 		return (P(x,y) - p).dist2();
@@ -48,7 +48,7 @@ struct KDTree {
 	Node* root;
 	KDTree(const vector<P>& vp) : root(new Node({all(vp)})) {}
 
-	pair<T, P> search(Node *node, const P& p) {
+	pair<T, P> search(Node *node, P p) {
 		if (!node->first) {
 			// uncomment if we should not find the point itself:
 			// if (p == node->pt) return {INF, P()};
@@ -68,7 +68,7 @@ struct KDTree {
 
 	// find nearest point to a point, and its squared distance
 	// (requires an arbitrary operator< for Point)
-	pair<T, P> nearest(const P& p) {
+	pair<T, P> nearest(P p) {
 		return search(root, p);
 	}
 };

--- a/content/geometry/lineDistance.h
+++ b/content/geometry/lineDistance.h
@@ -21,6 +21,6 @@ Using Point3D will always give a non-negative distance. For Point3D, call .dist 
 #include "Point.h"
 
 template<class P>
-double lineDist(const P& a, const P& b, const P& p) {
+double lineDist(P a, P b, P p) {
 	return (double)(b-a).cross(p-a)/(b-a).dist();
 }

--- a/content/geometry/linearTransformation.h
+++ b/content/geometry/linearTransformation.h
@@ -19,8 +19,7 @@
 #include "Point.h"
 
 typedef Point<double> P;
-P linearTransformation(const P& p0, const P& p1,
-		const P& q0, const P& q1, const P& r) {
+P linearTransformation(P p0, P p1, P q0, P q1, P r) {
 	P dp = p1-p0, dq = q1-q0, num(dp.cross(dq), dp.dot(dq));
 	return q0 + P((r-p0).cross(num), (r-p0).dot(num))/dp.dist2();
 }

--- a/content/geometry/sideOf.h
+++ b/content/geometry/sideOf.h
@@ -19,7 +19,7 @@ template<class P>
 int sideOf(P s, P e, P p) { return sgn(s.cross(e, p)); }
 
 template<class P>
-int sideOf(const P& s, const P& e, const P& p, double eps) {
+int sideOf(P s, P e, P p, double eps) {
 	auto a = (e-s).cross(p-s);
 	double l = (e-s).dist()*eps;
 	return (a > l) - (a < -l);


### PR DESCRIPTION
In geometry, it's mixed whether points are passed as `P&`, `const P&` or `P`. We should probably be consistent. Personally, I prefer just P. We should never have `P&`: then you can't do reasonable things such as:
```c++
auto eval = [&](double p) {
    return segDist(a, b, c + delta * p);
};
```