### PR TITLE
Add missing const in cf hashing

### DIFF
--- a/content/strings/Hashing-codeforces.h
+++ b/content/strings/Hashing-codeforces.h
@@ -21,7 +21,7 @@ struct A {
 	A operator+(A o){int y = x+o.x; return{y - (y>=M)*M, b+o.b};}
 	A operator-(A o){int y = x-o.x; return{y + (y< 0)*M, b-o.b};}
 	A operator*(A o) { return {(int)(1LL*x*o.x % M), b*o.b}; }
-	explicit operator ull() { return x ^ (ull) b << 21; }
+	explicit operator ull() const { return x ^ (ull) b << 21; }
 	bool operator==(A o) const { return (ull)*this == (ull)o; }
 	bool operator<(A o) const { return (ull)*this < (ull)o; }
 };


### PR DESCRIPTION
Without operator ull() being marked const, it causes a compilation error on some compilers due to const functions operator==, operator< calling it.  (This would prevent some users from being able to test their code locally.)