### PR TITLE
Optimize and make Modint safer

### DIFF
--- a/content/number-theory/ModularArithmetic.h
+++ b/content/number-theory/ModularArithmetic.h
@@ -1,5 +1,5 @@
 /**
- * Author: Lukas Polacek
+ * Author: Lukas Polacek, Joshua Andersson
  * Date: 2009-09-28
  * License: CC0
  * Source: folklore
@@ -13,17 +13,18 @@
 const ll mod = 17; // change to something else
 struct Mod {
 	ll x;
-	Mod(ll xx) : x(xx) {}
-	Mod operator+(Mod b) { return Mod((x + b.x) % mod); }
-	Mod operator-(Mod b) { return Mod((x - b.x + mod) % mod); }
-	Mod operator*(Mod b) { return Mod((x * b.x) % mod); }
+	Mod(ll y) : Mod(y%mod+mod,0){}
+	Mod(ll y,int) : x(y<mod?y:y-mod){}
+	Mod operator+(Mod b) { return {x + b.x,0}; }
+	Mod operator-(Mod b) { return {x - b.x + mod,0}; }
+	Mod operator*(Mod b) { return {x * b.x % mod,0}; }
 	Mod operator/(Mod b) { return *this * invert(b); }
 	Mod invert(Mod a) {
 		ll x, y, g = euclid(a.x, mod, x, y);
-		assert(g == 1); return Mod((x + mod) % mod);
+		assert(g == 1); return x;
 	}
 	Mod operator^(ll e) {
-		if (!e) return Mod(1);
+		if (!e) return 1;
 		Mod r = *this ^ (e / 2); r = r * r;
 		return e&1 ? *this * r : r;
 	}


### PR DESCRIPTION
The old modint was slightly footgunny because it didn't normalize in the constructor, so you could get un-normalized Mod structs if you passed numbers outside of $[0,mod)$. It's quite easy to miss this, especially if the input may contain negative numbers. To avoid performance regression from modding in the constructor, I add an "internal" constructor. The code is noticably faster for `+` and `-`. `*` should be about the same. The number of non-whitespace characters increases by 5.

- [Another Query on Array Problem](https://open.kattis.com/problems/queryonarray): [0.63s](https://pastebin.com/bT6B7Szy) -> [0.45s](https://pastebin.com/MWpE8VbG). The function poly is nicer after the rewrite.
- [Dark Alley](https://open.kattis.com/problems/darkalley) ~[0.49s](https://pastebin.com/Xbzbb29a) -> ~[0.47s](https://pastebin.com/3kunBYBY). After the rewrite, we don't need to mod our answer before cout:ing

